### PR TITLE
FEAT : 약관 목록 조회, 약관 상세 조회 기능 구현, 공통 에러 처리 추가

### DIFF
--- a/src/main/java/com/zb/fresh_api/api/common/GlobalResponse.java
+++ b/src/main/java/com/zb/fresh_api/api/common/GlobalResponse.java
@@ -1,0 +1,12 @@
+package com.zb.fresh_api.api.common;
+
+import lombok.Builder;
+
+@Builder
+public record GlobalResponse<T> (
+    boolean success,
+    String code,
+    String message,
+    T data
+){
+}

--- a/src/main/java/com/zb/fresh_api/api/common/ResponseCode.java
+++ b/src/main/java/com/zb/fresh_api/api/common/ResponseCode.java
@@ -6,9 +6,8 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum ResponseCode {
-
-    SUCCESS("0200", "응답 성공");
+    TERMS_NOT_FOUND("0404"),
+    SUCCESS("0200");
     private final String code;
-    private final String message;
 
 }

--- a/src/main/java/com/zb/fresh_api/api/common/ResponseCode.java
+++ b/src/main/java/com/zb/fresh_api/api/common/ResponseCode.java
@@ -1,0 +1,14 @@
+package com.zb.fresh_api.api.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ResponseCode {
+
+    SUCCESS("0200", "응답 성공");
+    private final String code;
+    private final String message;
+
+}

--- a/src/main/java/com/zb/fresh_api/api/common/exception/CustomException.java
+++ b/src/main/java/com/zb/fresh_api/api/common/exception/CustomException.java
@@ -1,0 +1,11 @@
+package com.zb.fresh_api.api.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends  RuntimeException{
+    private final ErrorCode errorCode;
+    public CustomException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/common/exception/ErrorCode.java
+++ b/src/main/java/com/zb/fresh_api/api/common/exception/ErrorCode.java
@@ -1,0 +1,14 @@
+package com.zb.fresh_api.api.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    TERMS_NOT_FOUND("약관 정보가 존재하지 않습니다", HttpStatus.NOT_FOUND);
+
+    private final String description;
+    private final HttpStatus httpStatus;
+}

--- a/src/main/java/com/zb/fresh_api/api/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zb/fresh_api/api/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.zb.fresh_api.api.common.exception;
+
+import com.zb.fresh_api.api.common.GlobalResponse;
+import com.zb.fresh_api.api.common.ResponseCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<GlobalResponse<?>> handleCustomException(final CustomException e) {
+
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(
+            GlobalResponse.builder()
+                .success(false)
+                .code(ResponseCode.TERMS_NOT_FOUND.getCode())
+                .message(e.getErrorCode().getDescription())
+                .data(null)
+                .build()
+        );
+    }
+
+}

--- a/src/main/java/com/zb/fresh_api/api/controller/TermsController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/TermsController.java
@@ -1,0 +1,43 @@
+package com.zb.fresh_api.api.controller;
+
+import com.zb.fresh_api.api.common.GlobalResponse;
+import com.zb.fresh_api.api.common.ResponseCode;
+import com.zb.fresh_api.api.dto.GetAllTermsResponse;
+import com.zb.fresh_api.api.dto.TermsDto;
+import com.zb.fresh_api.api.service.TermsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Tag(
+    name = "약관 API",
+    description = "회원가입 시 필요한 약관 관련 API"
+)
+@RestController
+@RequestMapping("/api/terms")
+@RequiredArgsConstructor
+public class TermsController {
+
+    private final TermsService termsService;
+
+
+    @Operation(
+        summary = "약관 목록 조회",
+        description = "서비스 이용에 필요한 약관 목록을 조회합니다"
+    )
+    @GetMapping
+    public GlobalResponse<List<GetAllTermsResponse>> getAllTerms(){
+        List<TermsDto> terms = termsService.getTerms();
+        return GlobalResponse.<List<GetAllTermsResponse>>builder()
+            .success(true)
+            .code(ResponseCode.SUCCESS.getCode())
+            .message("약관 목록 조회 성공")
+            .data(terms.stream().map(GetAllTermsResponse::fromDto).toList())
+            .build();
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/controller/TermsController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/TermsController.java
@@ -3,6 +3,7 @@ package com.zb.fresh_api.api.controller;
 import com.zb.fresh_api.api.common.GlobalResponse;
 import com.zb.fresh_api.api.common.ResponseCode;
 import com.zb.fresh_api.api.dto.GetAllTermsResponse;
+import com.zb.fresh_api.api.dto.GetTermsByIdResponse;
 import com.zb.fresh_api.api.dto.TermsDto;
 import com.zb.fresh_api.api.service.TermsService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -38,6 +40,23 @@ public class TermsController {
             .code(ResponseCode.SUCCESS.getCode())
             .message("약관 목록 조회 성공")
             .data(terms.stream().map(GetAllTermsResponse::fromDto).toList())
+            .build();
+    }
+
+
+    @Operation(
+        summary = "약관 상세 조회",
+        description = "약관의 Id를 이용해 약관을 상세 조회합니다"
+    )
+    @GetMapping("/{termsId}")
+    public GlobalResponse<GetTermsByIdResponse> getTermsById(@PathVariable("termsId") Long termsId){
+        TermsDto term = termsService.getTerm(termsId);
+
+        return GlobalResponse.<GetTermsByIdResponse>builder()
+            .success(true)
+            .code(ResponseCode.SUCCESS.getCode())
+            .message("약관 상세 조회 성공")
+            .data(GetTermsByIdResponse.fromDto(term))
             .build();
     }
 }

--- a/src/main/java/com/zb/fresh_api/api/dto/GetAllTermsResponse.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/GetAllTermsResponse.java
@@ -1,0 +1,20 @@
+package com.zb.fresh_api.api.dto;
+
+import lombok.Builder;
+
+@Builder
+public record GetAllTermsResponse
+    (
+        Long termsId,
+        String title,
+        boolean isRequired
+    ) {
+
+    public static GetAllTermsResponse fromDto(TermsDto dto) {
+        return GetAllTermsResponse.builder()
+            .termsId(dto.termsId())
+            .title(dto.title())
+            .isRequired(dto.isRequired())
+            .build();
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/dto/GetTermsByIdResponse.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/GetTermsByIdResponse.java
@@ -1,0 +1,18 @@
+package com.zb.fresh_api.api.dto;
+
+import lombok.Builder;
+
+@Builder
+public record GetTermsByIdResponse (
+    String title,
+    String content,
+    boolean isRequired
+){
+    public static GetTermsByIdResponse fromDto(TermsDto dto){
+        return GetTermsByIdResponse.builder()
+            .title(dto.title())
+            .content(dto.content())
+            .isRequired(dto.isRequired())
+            .build();
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/dto/TermsDto.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/TermsDto.java
@@ -7,13 +7,15 @@ import lombok.Builder;
 public record TermsDto(
     Long termsId,
     String title,
-    boolean isRequired
+    boolean isRequired,
+    String content
 ) {
     public static TermsDto from(Terms terms) {
         return TermsDto.builder()
             .termsId(terms.getId())
             .title(terms.getTitle())
             .isRequired(terms.isRequired())
+            .content(terms.getContent())
             .build();
     }
 }

--- a/src/main/java/com/zb/fresh_api/api/dto/TermsDto.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/TermsDto.java
@@ -1,0 +1,19 @@
+package com.zb.fresh_api.api.dto;
+
+import com.zb.fresh_api.domain.entity.terms.Terms;
+import lombok.Builder;
+
+@Builder
+public record TermsDto(
+    Long termsId,
+    String title,
+    boolean isRequired
+) {
+    public static TermsDto from(Terms terms) {
+        return TermsDto.builder()
+            .termsId(terms.getId())
+            .title(terms.getTitle())
+            .isRequired(terms.isRequired())
+            .build();
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/service/TermsService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/TermsService.java
@@ -1,5 +1,7 @@
 package com.zb.fresh_api.api.service;
 
+import com.zb.fresh_api.api.common.exception.CustomException;
+import com.zb.fresh_api.api.common.exception.ErrorCode;
 import com.zb.fresh_api.api.dto.TermsDto;
 import com.zb.fresh_api.domain.entity.terms.Terms;
 import com.zb.fresh_api.domain.repository.TermsRepository;
@@ -23,6 +25,12 @@ public class TermsService {
         return terms.stream().map(
             TermsDto::from
         ).toList();
+    }
 
+    public TermsDto getTerm(final Long termsId) {
+        Terms terms = termsRepository.findById(termsId).orElseThrow(
+            () -> new CustomException(ErrorCode.TERMS_NOT_FOUND)
+        );
+        return TermsDto.from(terms);
     }
 }

--- a/src/main/java/com/zb/fresh_api/api/service/TermsService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/TermsService.java
@@ -1,0 +1,28 @@
+package com.zb.fresh_api.api.service;
+
+import com.zb.fresh_api.api.dto.TermsDto;
+import com.zb.fresh_api.domain.entity.terms.Terms;
+import com.zb.fresh_api.domain.repository.TermsRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TermsService {
+
+    private final TermsRepository termsRepository;
+
+    /**
+     * 약관 목록 조회 로직
+     * @return 목록ID, 약관명, 필수여부
+     */
+    public List<TermsDto> getTerms() {
+        List<Terms> terms = termsRepository.findAll();
+
+        return terms.stream().map(
+            TermsDto::from
+        ).toList();
+
+    }
+}

--- a/src/main/java/com/zb/fresh_api/domain/converter/CodeConverter.java
+++ b/src/main/java/com/zb/fresh_api/domain/converter/CodeConverter.java
@@ -1,0 +1,28 @@
+package com.zb.fresh_api.domain.converter;
+
+import com.zb.fresh_api.domain.enums.Code;
+import jakarta.persistence.AttributeConverter;
+import lombok.AllArgsConstructor;
+
+import java.util.EnumSet;
+import java.util.NoSuchElementException;
+
+@AllArgsConstructor
+public class CodeConverter<E extends Enum<E> & Code> implements AttributeConverter<E, String> {
+
+    private final Class<E> target;
+
+    @Override
+    public String convertToDatabaseColumn(E code) {
+        return code.getCode();
+    }
+
+    @Override
+    public E convertToEntityAttribute(String code) {
+        return EnumSet.allOf(target).stream()
+                .filter(e -> e.getCode().equals(code))
+                .findAny()
+                .orElseThrow(NoSuchElementException::new);
+    }
+
+}

--- a/src/main/java/com/zb/fresh_api/domain/converter/TermsTypeConverter.java
+++ b/src/main/java/com/zb/fresh_api/domain/converter/TermsTypeConverter.java
@@ -1,0 +1,13 @@
+package com.zb.fresh_api.domain.converter;
+
+
+import com.zb.fresh_api.domain.enums.terms.TermsType;
+import jakarta.persistence.Converter;
+
+@Converter
+public class TermsTypeConverter extends CodeConverter<TermsType> {
+
+    public TermsTypeConverter() {
+        super(TermsType.class);
+    }
+}

--- a/src/main/java/com/zb/fresh_api/domain/entity/base/BaseTimeEntity.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/base/BaseTimeEntity.java
@@ -1,0 +1,26 @@
+package com.zb.fresh_api.domain.entity.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, columnDefinition = "datetime comment '생성일'")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", columnDefinition = "datetime comment '수정일'")
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/zb/fresh_api/domain/entity/member/Member.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/member/Member.java
@@ -1,0 +1,64 @@
+package com.zb.fresh_api.domain.entity.member;
+
+import com.zb.fresh_api.domain.entity.base.BaseTimeEntity;
+import com.zb.fresh_api.domain.enums.member.MemberRole;
+import com.zb.fresh_api.domain.enums.member.MemberStatus;
+import com.zb.fresh_api.domain.enums.member.Provider;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(
+        name = "member"
+)
+public class Member extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", columnDefinition = "BIGINT UNSIGNED comment '고유 번호'")
+    private Long id;
+
+    @Column(name = "email", nullable = false, columnDefinition = "varchar(255) comment '이메일'")
+    private String email;
+
+    @Column(name = "name", columnDefinition = "varchar(20) comment '회원 이름'")
+    private String name;
+
+    @Column(name = "nickname", nullable = false, columnDefinition = "varchar(20) comment '닉네임'")
+    private String nickname;
+
+    @Column(name = "password", columnDefinition = "varchar(255) comment '비밀번호'")
+    private String password;
+
+    @Column(name = "phone", columnDefinition = "varchar(20) comment '전화번호'")
+    private String phone;
+
+    @Column(name = "profile_image", columnDefinition = "varchar(255) comment '프로필 이미지'")
+    private String profileImage;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", nullable = false, columnDefinition = "varchar(20) comment '가입 경로'")
+    private Provider provider;
+
+    @Column(name = "provider_id", columnDefinition = "varchar(255) comment '공급 번호'")
+    private String providerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, columnDefinition = "varchar(20) comment '회원 상태'")
+    private MemberStatus status;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, columnDefinition = "varchar(20) comment '권한'")
+    private MemberRole role = MemberRole.ROLE_USER;
+
+    @Column(name = "deleted_at", columnDefinition = "datetime comment '탈퇴 일시'")
+    private LocalDateTime deletedAt;
+
+}

--- a/src/main/java/com/zb/fresh_api/domain/entity/member/MemberTerms.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/member/MemberTerms.java
@@ -1,0 +1,43 @@
+package com.zb.fresh_api.domain.entity.member;
+
+import com.zb.fresh_api.domain.entity.base.BaseTimeEntity;
+import com.zb.fresh_api.domain.entity.terms.Terms;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(
+    name = "member_terms"
+)
+public class MemberTerms extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", columnDefinition = "BIGINT UNSIGNED comment '약관 고유 번호'")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false, columnDefinition = "BIGINT UNSIGNED comment '회원 고유 번호'")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "terms_id", nullable = false, columnDefinition = "BIGINT UNSIGNED comment '약관 고유 번호'")
+    private Terms terms;
+
+    @Column(name = "agreed_at", columnDefinition = "datetime comment '동의 일시'")
+    private LocalDateTime agreedAt;
+
+    public static MemberTerms create(Member member, Terms terms, boolean isAgreed, LocalDateTime agreedAt) {
+        return MemberTerms.builder()
+            .member(member)
+            .terms(terms)
+            .agreedAt(isAgreed ? agreedAt : null)
+            .build();
+    }
+}

--- a/src/main/java/com/zb/fresh_api/domain/entity/terms/Terms.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/terms/Terms.java
@@ -1,0 +1,55 @@
+package com.zb.fresh_api.domain.entity.terms;
+
+
+import com.zb.fresh_api.domain.converter.TermsTypeConverter;
+import com.zb.fresh_api.domain.entity.base.BaseTimeEntity;
+import com.zb.fresh_api.domain.enums.terms.TermsType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(
+        name = "terms"
+)
+public class Terms extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", columnDefinition = "BIGINT UNSIGNED comment '고유 번호'")
+    private Long id;
+
+    @Column(name = "title", nullable = false, columnDefinition = "varchar(20) comment '약관명'")
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "mediumtext comment '약관 내용'")
+    private String content;
+
+    @Convert(converter = TermsTypeConverter.class)
+    @Column(name = "type", nullable = false, updatable = false, columnDefinition = "varchar(8) comment '약관 타입'")
+    private TermsType type;
+
+    @Column(name = "is_used", columnDefinition = "tinyint comment '사용 여부'")
+    private boolean isUsed;
+
+    @Column(name = "is_required", columnDefinition = "tinyint comment '필수 여부'")
+    private boolean isRequired;
+
+    @Column(name = "deleted_at", columnDefinition = "datetime comment '삭제 일시'")
+    private LocalDateTime deletedAt;
+
+    public void use() {
+        this.isUsed = true;
+    }
+
+    public void stopUse() {
+        this.isUsed = false;
+    }
+}

--- a/src/main/java/com/zb/fresh_api/domain/enums/Code.java
+++ b/src/main/java/com/zb/fresh_api/domain/enums/Code.java
@@ -1,0 +1,6 @@
+package com.zb.fresh_api.domain.enums;
+
+public interface Code {
+
+    String getCode();
+}

--- a/src/main/java/com/zb/fresh_api/domain/enums/member/MemberRole.java
+++ b/src/main/java/com/zb/fresh_api/domain/enums/member/MemberRole.java
@@ -1,0 +1,5 @@
+package com.zb.fresh_api.domain.enums.member;
+
+public enum MemberRole {
+    ROLE_ADMIN, ROLE_USER
+}

--- a/src/main/java/com/zb/fresh_api/domain/enums/member/MemberStatus.java
+++ b/src/main/java/com/zb/fresh_api/domain/enums/member/MemberStatus.java
@@ -1,0 +1,5 @@
+package com.zb.fresh_api.domain.enums.member;
+
+public enum MemberStatus {
+    INACTIVE, ACTIVE, WITHDRAWAL
+}

--- a/src/main/java/com/zb/fresh_api/domain/enums/member/Provider.java
+++ b/src/main/java/com/zb/fresh_api/domain/enums/member/Provider.java
@@ -1,0 +1,5 @@
+package com.zb.fresh_api.domain.enums.member;
+
+public enum Provider {
+    EMAIL, KAKAO, NAVER,
+}

--- a/src/main/java/com/zb/fresh_api/domain/enums/terms/TermsType.java
+++ b/src/main/java/com/zb/fresh_api/domain/enums/terms/TermsType.java
@@ -1,0 +1,18 @@
+package com.zb.fresh_api.domain.enums.terms;
+
+import com.zb.fresh_api.domain.enums.Code;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum TermsType implements Code {
+
+    SERVICE("TT000", "서비스 이용약관"),
+    PRIVACY("TT001", "개인정보 수집 및 이용동의"),
+    MARKETING("TT002", "마케팅 수신")
+    ;
+
+    private final String code;
+    private final String description;
+}

--- a/src/main/java/com/zb/fresh_api/domain/repository/TermsRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/TermsRepository.java
@@ -1,0 +1,10 @@
+package com.zb.fresh_api.domain.repository;
+
+import com.zb.fresh_api.domain.entity.terms.Terms;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TermsRepository extends JpaRepository<Terms, Long> {
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,11 +1,6 @@
 spring:
   profiles:
     active: local
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url : jdbc:mysql://localhost:3306/fresh
-    username: root
-    password: root
 # swagger
 springdoc:
   api-docs:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,11 @@
 spring:
   profiles:
     active: local
-
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url : jdbc:mysql://localhost:3306/fresh
+    username: root
+    password: root
 # swagger
 springdoc:
   api-docs:


### PR DESCRIPTION
## 작업

* 약관 목록을 조회 API 추가하였습니다.
* 약관 상세 조회 API 추가하였습니다.
* 공통 에러 처리 핸들러 구현

## 참고 사항

* 임의로 mysql 접속 정보를 application.yml에 추가하였습니다
* API 공통 응답 record 추가하였습니다.
* 공통 에러 처리를 위한 클래스 CustomException, ErrorCode, GlobalExceptionHandler 제가 임의로 구현하였는데 피드백부탁드립니다!!

## 관련 이슈
- #2 
