### PR TITLE
FEAT : 휴대폰 인증 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,11 @@ dependencies {
 	// validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation:3.3.3'
 
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.3.3'
+	// sms
+	implementation 'net.nurigo:sdk:4.3.0'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/zb/fresh_api/api/config/RedisConfig.java
+++ b/src/main/java/com/zb/fresh_api/api/config/RedisConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
@@ -24,6 +25,8 @@ public class RedisConfig {
     public StringRedisTemplate stringRedisTemplate() {
         StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
         stringRedisTemplate.setConnectionFactory(redisConnectionFactory());
+        stringRedisTemplate.setKeySerializer(new StringRedisSerializer());
+        stringRedisTemplate.setValueSerializer(new StringRedisSerializer());
         return stringRedisTemplate;
     }
 

--- a/src/main/java/com/zb/fresh_api/api/config/RedisConfig.java
+++ b/src/main/java/com/zb/fresh_api/api/config/RedisConfig.java
@@ -1,0 +1,30 @@
+package com.zb.fresh_api.api.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate() {
+        StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
+        stringRedisTemplate.setConnectionFactory(redisConnectionFactory());
+        return stringRedisTemplate;
+    }
+
+}

--- a/src/main/java/com/zb/fresh_api/api/controller/SmsController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/SmsController.java
@@ -1,0 +1,41 @@
+package com.zb.fresh_api.api.controller;
+
+import com.zb.fresh_api.api.service.SmsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+    name = "휴대전화 인증 API",
+    description = "휴대전화 인증에 관련된 API"
+)
+@RestController
+@RequestMapping("/v1/api/sms")
+@RequiredArgsConstructor
+public class SmsController {
+
+    private final SmsService smsService;
+
+    @Operation(
+        summary = "인증 문자 전송",
+        description = "입력한 휴대전화로 인증번호를 전송합니다"
+    )
+    @GetMapping
+    public void sendSms(@RequestParam String phoneNumber) {
+        smsService.sendSms(phoneNumber);
+    }
+
+    @Operation(
+        summary = "인증 코드 인증",
+        description = "휴대전화로 온 인증코드를 통해 인증합니다"
+    )
+    @GetMapping("/certificate")
+    public void certificateSms(@RequestParam String phoneNumber,
+        @RequestParam String certificationCode) {
+        smsService.certificateCode(phoneNumber, certificationCode);
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/service/RedisService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/RedisService.java
@@ -1,0 +1,55 @@
+package com.zb.fresh_api.api.service;
+
+import java.time.Duration;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String PREFIX = "sms:";
+    private static final String ATTEMPT_PREFIX = "attempt:";
+    private static final int CODE_EXPIRATION_TIME = 5 * 60;
+    private static final int ATTEMPT_EXPIRATION_TIME = 30 * 60;
+    private static final int MAX_ATTEMPTS = 5;
+
+    // 문자 인증의 인증 코드 저장 메서드
+    public void saveCertificationCode(String phone, String certificationNumber) {
+        redisTemplate.opsForValue()
+            .set(PREFIX + phone, certificationNumber, Duration.ofSeconds(CODE_EXPIRATION_TIME));
+    }
+
+    // 문자 인증 코드 찾는 메서드
+    public String findSmsCertification(String phone) {
+        return redisTemplate.opsForValue().get(PREFIX + phone);
+    }
+
+    // 문자 인증 코드 제거 메서드
+    public void removeSmsCertification(String phone) {
+        redisTemplate.delete(PREFIX + phone);
+        redisTemplate.delete(PREFIX + ATTEMPT_PREFIX + phone);
+    }
+
+    // 인증 횟수 초과 확인 메서드
+    public boolean hasExceededAttemptLimit(String phone) {
+        String key = PREFIX + ATTEMPT_PREFIX + phone;
+        int attempts = redisTemplate.opsForValue().get(key) != null ? Integer.parseInt(
+            Objects.requireNonNull(redisTemplate.opsForValue().get(key))) : 0;
+        return attempts >= MAX_ATTEMPTS;
+    }
+
+    // 문자 인증 횟수 기록 메서드
+    public void recordAttempt(String phone) {
+        String key = PREFIX + ATTEMPT_PREFIX + phone;
+        int attempts = redisTemplate.opsForValue().get(key) != null ? Integer.parseInt(
+            Objects.requireNonNull(redisTemplate.opsForValue().get(key))) : 0;
+        attempts++;
+        redisTemplate.opsForValue()
+            .set(key, String.valueOf(attempts), Duration.ofSeconds(ATTEMPT_EXPIRATION_TIME));
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/service/SmsService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/SmsService.java
@@ -1,7 +1,10 @@
 package com.zb.fresh_api.api.service;
 
+import com.zb.fresh_api.common.exception.CustomException;
+import com.zb.fresh_api.common.exception.ResponseCode;
 import jakarta.annotation.PostConstruct;
 import java.security.SecureRandom;
+import lombok.RequiredArgsConstructor;
 import net.nurigo.sdk.NurigoApp;
 import net.nurigo.sdk.message.model.Message;
 import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
@@ -10,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class SmsService {
 
     @Value("${spring.coolsms.apiKey}") // coolsms의 API 키 주입
@@ -20,7 +24,12 @@ public class SmsService {
 
     @Value("${spring.coolsms.fromNumber}") // 발신자 번호 주입
     private String fromNumber;
+
+    @Value("${spring.coolsms.apiUrl}")
+    private String apiUrl;
+
     DefaultMessageService messageService;
+    private final RedisService redisService;
 
     private static final String CHAR_LOWER = "abcdefghijklmnopqrstuvwxyz";
     private static final String CHAR_UPPER = CHAR_LOWER.toUpperCase();
@@ -29,19 +38,56 @@ public class SmsService {
     private static final SecureRandom random = new SecureRandom();
     private static final int CODE_LENGTH = 6;
 
+
     @PostConstruct
     private void init() {
-        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret,
-            "https://api.coolsms.co.kr");
+        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, apiUrl);
     }
 
+    /**
+     * 문자 인증 코드 전송 로직
+     * 1. 현재 전화번호의 요청이 제한 횟수 이상 왔는지 검증
+     * 2. 인증 문자 전송
+     * 3. 인증 유효시간 설정
+     * 4. 인증 문자 전송 횟수 기록
+     */
     public void sendSms(String toNumber) {
-        Message message = new Message();
+        if (redisService.hasExceededAttemptLimit(toNumber)) {
+            throw new CustomException(ResponseCode.EXCEEDED_CERTIFICATION_ATTEMPS);
+        }
         String certificationCode = this.generateRandomString();
+        this.sendCertificationCode(toNumber, certificationCode);
+        redisService.saveCertificationCode(toNumber, certificationCode);
+        redisService.recordAttempt(toNumber);
+    }
+
+    /**
+     * 문자 인증 코드 인증 로직
+     * 1. 휴대전화 인증 내역 조회 후 없으면 에러 발생
+     * 2. 인증 코드가 일치하면 성공 로직 구현(미정) 일치하지 않으면 에러 발생
+     * 3. redis에서 휴대전화 관련 데이터 삭제
+     */
+    public void certificateCode(String phone, String certificationCode){
+        String smsCertification = redisService.findSmsCertification(phone);
+        if(smsCertification == null){
+            throw new CustomException(ResponseCode.CERTIFICATION_NOT_FOUND);
+        }
+        if(certificationCode.equals(smsCertification)){
+            // TODO 문자 인증 성공 시 로직 구현
+            // System.out.println("문자 인증 성공~");
+        }else{
+            throw new CustomException(ResponseCode.CERTIFICATION_CODE_NOT_CORRECT);
+        }
+        redisService.removeSmsCertification(phone);
+    }
+
+    // 인증 문자 전송 메서드
+    private void sendCertificationCode(String toNumber, String certificationCode) {
+        Message message = new Message();
         message.setFrom(fromNumber);
         message.setTo(toNumber);
         message.setText("[Fresh 2 you] \n" + "본인확인 인증번호는 " + certificationCode + "입니다.");
-        this.messageService.sendOne(new SingleMessageSendingRequest(message));
+        messageService.sendOne(new SingleMessageSendingRequest(message));
     }
 
     private String generateRandomString() {

--- a/src/main/java/com/zb/fresh_api/api/service/SmsService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/SmsService.java
@@ -1,64 +1,33 @@
 package com.zb.fresh_api.api.service;
 
+import com.zb.fresh_api.api.utils.RedisUtil;
+import com.zb.fresh_api.api.utils.SmsUtil;
 import com.zb.fresh_api.common.exception.CustomException;
 import com.zb.fresh_api.common.exception.ResponseCode;
-import jakarta.annotation.PostConstruct;
-import java.security.SecureRandom;
 import lombok.RequiredArgsConstructor;
-import net.nurigo.sdk.NurigoApp;
-import net.nurigo.sdk.message.model.Message;
-import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
-import net.nurigo.sdk.message.service.DefaultMessageService;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
+@Service
 @RequiredArgsConstructor
 public class SmsService {
 
-    @Value("${spring.coolsms.apiKey}") // coolsms의 API 키 주입
-    private String apiKey;
-
-    @Value("${spring.coolsms.apiSecret}") // coolsms의 API 비밀키 주입
-    private String apiSecret;
-
-    @Value("${spring.coolsms.fromNumber}") // 발신자 번호 주입
-    private String fromNumber;
-
-    @Value("${spring.coolsms.apiUrl}")
-    private String apiUrl;
-
-    DefaultMessageService messageService;
-    private final RedisService redisService;
-
-    private static final String CHAR_LOWER = "abcdefghijklmnopqrstuvwxyz";
-    private static final String CHAR_UPPER = CHAR_LOWER.toUpperCase();
-    private static final String NUMBER = "0123456789";
-    private static final String DATA_FOR_RANDOM_STRING = CHAR_LOWER + CHAR_UPPER + NUMBER;
-    private static final SecureRandom random = new SecureRandom();
-    private static final int CODE_LENGTH = 6;
-
-
-    @PostConstruct
-    private void init() {
-        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, apiUrl);
-    }
+    private final RedisUtil redisUtil;
+    private final SmsUtil smsUtil;
 
     /**
-     * 문자 인증 코드 전송 로직
-     * 1. 현재 전화번호의 요청이 제한 횟수 이상 왔는지 검증
+     * 문자 인증 코드 전송 로직 1. 현재 전화번호의 요청이 제한 횟수 이상 왔는지 검증
      * 2. 인증 문자 전송
      * 3. 인증 유효시간 설정
      * 4. 인증 문자 전송 횟수 기록
      */
     public void sendSms(String toNumber) {
-        if (redisService.hasExceededAttemptLimit(toNumber)) {
+        if (redisUtil.hasExceededAttemptLimit(toNumber)) {
             throw new CustomException(ResponseCode.EXCEEDED_CERTIFICATION_ATTEMPS);
         }
-        String certificationCode = this.generateRandomString();
-        this.sendCertificationCode(toNumber, certificationCode);
-        redisService.saveCertificationCode(toNumber, certificationCode);
-        redisService.recordAttempt(toNumber);
+        String certificationCode = smsUtil.generateRandomString();
+        smsUtil.sendCertificationCode(toNumber, certificationCode);
+        redisUtil.saveCertificationCode(toNumber, certificationCode);
+        redisUtil.recordAttempt(toNumber);
     }
 
     /**
@@ -67,37 +36,17 @@ public class SmsService {
      * 2. 인증 코드가 일치하면 성공 로직 구현(미정) 일치하지 않으면 에러 발생
      * 3. redis에서 휴대전화 관련 데이터 삭제
      */
-    public void certificateCode(String phone, String certificationCode){
-        String smsCertification = redisService.findSmsCertification(phone);
-        if(smsCertification == null){
+    public void certificateCode(String phone, String certificationCode) {
+        String smsCertification = redisUtil.findSmsCertification(phone);
+        if (smsCertification == null) {
             throw new CustomException(ResponseCode.CERTIFICATION_NOT_FOUND);
         }
-        if(certificationCode.equals(smsCertification)){
+        if (certificationCode.equals(smsCertification)) {
             // TODO 문자 인증 성공 시 로직 구현
-            // System.out.println("문자 인증 성공~");
-        }else{
+             System.out.println("문자 인증 성공~");
+        } else {
             throw new CustomException(ResponseCode.CERTIFICATION_CODE_NOT_CORRECT);
         }
-        redisService.removeSmsCertification(phone);
-    }
-
-    // 인증 문자 전송 메서드
-    private void sendCertificationCode(String toNumber, String certificationCode) {
-        Message message = new Message();
-        message.setFrom(fromNumber);
-        message.setTo(toNumber);
-        message.setText("[Fresh 2 you] \n" + "본인확인 인증번호는 " + certificationCode + "입니다.");
-        messageService.sendOne(new SingleMessageSendingRequest(message));
-    }
-
-    private String generateRandomString() {
-        StringBuilder sb = new StringBuilder(CODE_LENGTH);
-        for (int i = 0; i < CODE_LENGTH; i++) {
-            int rndCharAt = random.nextInt(DATA_FOR_RANDOM_STRING.length());
-            char rndChar = DATA_FOR_RANDOM_STRING.charAt(rndCharAt);
-            sb.append(rndChar);
-        }
-
-        return sb.toString();
+        redisUtil.removeSmsCertification(phone);
     }
 }

--- a/src/main/java/com/zb/fresh_api/api/service/SmsService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/SmsService.java
@@ -1,0 +1,35 @@
+package com.zb.fresh_api.api.service;
+
+import jakarta.annotation.PostConstruct;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SmsService {
+    @Value("${spring.coolsms.apiKey}") // coolsms의 API 키 주입
+    private String apiKey;
+
+    @Value("${spring.coolsms.apiSecret}") // coolsms의 API 비밀키 주입
+    private String apiSecret;
+
+    @Value("${spring.coolsms.fromNumber}") // 발신자 번호 주입
+    private String fromNumber;
+    DefaultMessageService messageService;
+    @PostConstruct
+    private void init(){
+        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr");
+    }
+
+    public void sendSms(String toNumber, String certificationCode) {
+        Message message = new Message();
+        message.setFrom(fromNumber);
+        message.setTo(toNumber);
+        message.setText("[Fresh 2 you] \n" + "본인확인 인증번호는 " + certificationCode + "입니다." );
+        System.out.println("test2");
+        this.messageService.sendOne(new SingleMessageSendingRequest(message));
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/service/SmsService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/SmsService.java
@@ -1,6 +1,7 @@
 package com.zb.fresh_api.api.service;
 
 import jakarta.annotation.PostConstruct;
+import java.security.SecureRandom;
 import net.nurigo.sdk.NurigoApp;
 import net.nurigo.sdk.message.model.Message;
 import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class SmsService {
+
     @Value("${spring.coolsms.apiKey}") // coolsms의 API 키 주입
     private String apiKey;
 
@@ -19,17 +21,37 @@ public class SmsService {
     @Value("${spring.coolsms.fromNumber}") // 발신자 번호 주입
     private String fromNumber;
     DefaultMessageService messageService;
+
+    private static final String CHAR_LOWER = "abcdefghijklmnopqrstuvwxyz";
+    private static final String CHAR_UPPER = CHAR_LOWER.toUpperCase();
+    private static final String NUMBER = "0123456789";
+    private static final String DATA_FOR_RANDOM_STRING = CHAR_LOWER + CHAR_UPPER + NUMBER;
+    private static final SecureRandom random = new SecureRandom();
+    private static final int CODE_LENGTH = 6;
+
     @PostConstruct
-    private void init(){
-        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr");
+    private void init() {
+        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret,
+            "https://api.coolsms.co.kr");
     }
 
-    public void sendSms(String toNumber, String certificationCode) {
+    public void sendSms(String toNumber) {
         Message message = new Message();
+        String certificationCode = this.generateRandomString();
         message.setFrom(fromNumber);
         message.setTo(toNumber);
-        message.setText("[Fresh 2 you] \n" + "본인확인 인증번호는 " + certificationCode + "입니다." );
-        System.out.println("test2");
+        message.setText("[Fresh 2 you] \n" + "본인확인 인증번호는 " + certificationCode + "입니다.");
         this.messageService.sendOne(new SingleMessageSendingRequest(message));
+    }
+
+    private String generateRandomString() {
+        StringBuilder sb = new StringBuilder(CODE_LENGTH);
+        for (int i = 0; i < CODE_LENGTH; i++) {
+            int rndCharAt = random.nextInt(DATA_FOR_RANDOM_STRING.length());
+            char rndChar = DATA_FOR_RANDOM_STRING.charAt(rndCharAt);
+            sb.append(rndChar);
+        }
+
+        return sb.toString();
     }
 }

--- a/src/main/java/com/zb/fresh_api/api/utils/RedisUtil.java
+++ b/src/main/java/com/zb/fresh_api/api/utils/RedisUtil.java
@@ -1,4 +1,4 @@
-package com.zb.fresh_api.api.service;
+package com.zb.fresh_api.api.utils;
 
 import java.time.Duration;
 import java.util.Objects;
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class RedisService {
+public class RedisUtil {
 
     private final StringRedisTemplate redisTemplate;
 

--- a/src/main/java/com/zb/fresh_api/api/utils/SmsUtil.java
+++ b/src/main/java/com/zb/fresh_api/api/utils/SmsUtil.java
@@ -1,0 +1,64 @@
+package com.zb.fresh_api.api.utils;
+
+
+import jakarta.annotation.PostConstruct;
+import java.security.SecureRandom;
+import lombok.RequiredArgsConstructor;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SmsUtil {
+
+    @Value("${spring.coolsms.apiKey}") // coolsms의 API 키 주입
+    private String apiKey;
+
+    @Value("${spring.coolsms.apiSecret}") // coolsms의 API 비밀키 주입
+    private String apiSecret;
+
+    @Value("${spring.coolsms.fromNumber}") // 발신자 번호 주입
+    private String fromNumber;
+
+    @Value("${spring.coolsms.apiUrl}")
+    private String apiUrl;
+
+    DefaultMessageService messageService;
+
+    private static final String CHAR_LOWER = "abcdefghijklmnopqrstuvwxyz";
+    private static final String CHAR_UPPER = CHAR_LOWER.toUpperCase();
+    private static final String NUMBER = "0123456789";
+    private static final String DATA_FOR_RANDOM_STRING = CHAR_LOWER + CHAR_UPPER + NUMBER;
+    private static final SecureRandom random = new SecureRandom();
+    private static final int CODE_LENGTH = 6;
+
+    @PostConstruct
+    private void init() {
+        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, apiUrl);
+    }
+
+    public String generateRandomString() {
+        StringBuilder sb = new StringBuilder(CODE_LENGTH);
+        for (int i = 0; i < CODE_LENGTH; i++) {
+            int rndCharAt = random.nextInt(DATA_FOR_RANDOM_STRING.length());
+            char rndChar = DATA_FOR_RANDOM_STRING.charAt(rndCharAt);
+            sb.append(rndChar);
+        }
+
+        return sb.toString();
+    }
+
+    // 인증 문자 전송 메서드
+    public void sendCertificationCode(String toNumber, String certificationCode) {
+        Message message = new Message();
+        message.setFrom(fromNumber);
+        message.setTo(toNumber);
+        message.setText("[Fresh 2 you] \n" + "본인확인 인증번호는 " + certificationCode + "입니다.");
+        messageService.sendOne(new SingleMessageSendingRequest(message));
+    }
+
+}

--- a/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
+++ b/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
@@ -56,6 +56,12 @@ public enum ResponseCode {
     SIGNATURE_EXCEPTION("1303", "토큰 서명이 올바르지 않습니다."),
     ILLEGAL_ARGUMENT_EXCEPTION("1304", "잘못된 인자가 전달되었습니다."),
 
+    /**
+     * SMS (1400 ~ 1500)
+     */
+    EXCEEDED_CERTIFICATION_ATTEMPS("1400", "30분 내에 인증 요청 횟수를 초과했습니다."),
+    CERTIFICATION_NOT_FOUND("1401", "인증 유효시간을 초과했습니다"),
+    CERTIFICATION_CODE_NOT_CORRECT("1402", "인증 코드가 일치하지 않습니다")
     ;
 
     private final String code;


### PR DESCRIPTION
## 작업

1. coolSMS와 연동하여 문자 전송 기능/API를 추가하였습니다.
  * 전송한 문자는 redis를 통해 관리합니다.
2. 전송한 문자의 인증 코드를 검증하는 기능/API를 추가하였습니다.
3. 문자 인증 조건은 다음과 같습니다.
  * 6가지 영어 소문자, 대문자와 숫자를 조합해 인증 코드 생성
  * 문자 전송 뒤 5분 이내에 인증 해야함
  * 30분 이내에 같은 번호로 5회 이상 보낼 시 30분 동안 인증 요청 할 수 없음

## 참고 사항

* 비즈니스 로직이 확정이 아니라(휴대폰 인증 시기) TODO로 남겼습니다.
* 설정 파일은 슬랙에 따로 업로드 하겠습니다.
* 테스트 코드는 이후 작성 예정입니다 (기능 테스트는 했습니다.

## 관련 이슈
- #8 