### PR TITLE
FEAT : 회원가입 API 공통화, 이메일 유효성 검증 위치 변경, 테스트 코드 변경, 회원가입 API 주석 작성 등

### DIFF
--- a/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
@@ -51,10 +51,6 @@ public class MemberController {
     public ResponseEntity<ApiResponse<Void>> checkEmailAvailability(
         @RequestParam String email
     ) {
-        if (email == null || email.isEmpty()) {
-            throw new CustomException(ResponseCode.PARAM_NICKNAME_NOT_VALID);
-
-        }
         memberService.emailValidate(email, Provider.EMAIL);
         return ApiResponse.success(ResponseCode.SUCCESS);
     }

--- a/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
@@ -58,6 +58,11 @@ public class MemberController {
         return ApiResponse.success(ResponseCode.SUCCESS);
     }
 
+    
+    @Operation(
+        summary = "회원 가입",
+        description = "이메일회원가입, Oauth2회원가입에 사용되는 API입니다"
+    )
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Void>> signUp(@RequestBody @Valid SignUpRequest request) {
         memberService.signUp(request.email(), request.password(), request.nickname(), request.termsAgreements());

--- a/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.zb.fresh_api.common.exception.CustomException;
 import com.zb.fresh_api.common.exception.ResponseCode;
 import com.zb.fresh_api.api.dto.SignUpRequest;
 import com.zb.fresh_api.api.service.MemberService;
+import com.zb.fresh_api.domain.enums.member.Provider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -54,7 +55,7 @@ public class MemberController {
             throw new CustomException(ResponseCode.PARAM_NICKNAME_NOT_VALID);
 
         }
-        memberService.emailValidate(email);
+        memberService.emailValidate(email, Provider.EMAIL);
         return ApiResponse.success(ResponseCode.SUCCESS);
     }
 
@@ -65,7 +66,8 @@ public class MemberController {
     )
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Void>> signUp(@RequestBody @Valid SignUpRequest request) {
-        memberService.signUp(request.email(), request.password(), request.nickname(), request.termsAgreements());
+        memberService.signUp(request.email(), request.password(), request.nickname(), request.termsAgreements()
+        ,request.provider(), request.providerId());
         return ApiResponse.success(ResponseCode.SUCCESS);
     }
 

--- a/src/main/java/com/zb/fresh_api/api/dto/SignUpRequest.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/SignUpRequest.java
@@ -1,6 +1,7 @@
 package com.zb.fresh_api.api.dto;
 
 import com.zb.fresh_api.api.validation.annotation.PasswordMatch;
+import com.zb.fresh_api.domain.enums.member.Provider;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -21,5 +22,10 @@ public record SignUpRequest (
     String nickname,
 
     @NotNull(message = "사용자 이용약관 동의은 필수입니다")
-    List<@Valid TermsAgreementDto> termsAgreements
+    List<@Valid TermsAgreementDto> termsAgreements,
+
+    @NotNull(message = "Provider는 필수입니다")
+    Provider provider,
+
+    String providerId
 ){}

--- a/src/main/java/com/zb/fresh_api/api/service/MemberService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/MemberService.java
@@ -40,6 +40,9 @@ public class MemberService {
     }
 
     public void emailValidate(String email, Provider provider) {
+        if (email == null || email.isEmpty()) {
+            throw new CustomException(ResponseCode.PARAM_EMAIL_NOT_VALID);
+        }
         boolean existsByEmailAndProvider = memberJpaRepository.existsByEmailAndProvider(email,
             provider);
         if (existsByEmailAndProvider) {

--- a/src/main/java/com/zb/fresh_api/api/service/MemberService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/MemberService.java
@@ -39,9 +39,9 @@ public class MemberService {
         }
     }
 
-    public void emailValidate(String email) {
+    public void emailValidate(String email, Provider provider) {
         boolean existsByEmailAndProvider = memberJpaRepository.existsByEmailAndProvider(email,
-            Provider.EMAIL);
+            provider);
         if (existsByEmailAndProvider) {
             throw new CustomException(ResponseCode.EMAIL_ALREADY_IN_USE);
         }
@@ -57,16 +57,17 @@ public class MemberService {
      */
     @Transactional(readOnly = false)
     public void signUp(String email, String password, String nickName,
-        List<TermsAgreementDto> termsAgreementDtos) {
+        List<TermsAgreementDto> termsAgreementDtos, Provider provider, String providerId) {
         this.nickNameValidate(nickName);
-        this.emailValidate(email);
+        this.emailValidate(email, provider);
         validateMandatoryTermsIncluded(termsAgreementDtos);
         Member member = memberJpaRepository.save(
             Member.builder()
                 .nickname(nickName)
                 .email(email)
                 .password(passwordEncoder.encode(password))
-                .provider(Provider.EMAIL)
+                .provider(provider)
+                .providerId(providerId)
                 .role(MemberRole.ROLE_USER)
                 .status(MemberStatus.ACTIVE)
                 .build()

--- a/src/test/java/com/zb/fresh_api/api/service/MemberServiceTest.java
+++ b/src/test/java/com/zb/fresh_api/api/service/MemberServiceTest.java
@@ -68,7 +68,7 @@ class MemberServiceTest {
             any(Provider.class))).thenReturn(true);
 
         // when & then
-        assertThatThrownBy(() -> memberService.emailValidate("test@test.com"))
+        assertThatThrownBy(() -> memberService.emailValidate("test@test.com", Provider.EMAIL))
             .isInstanceOf(CustomException.class)
             .hasMessage(ResponseCode.EMAIL_ALREADY_IN_USE.getMessage());
     }
@@ -106,7 +106,8 @@ class MemberServiceTest {
         );
 
         // when
-        memberService.signUp("test@test.com", "password", "gin", termsAgreementDtos);
+        memberService.signUp("test@test.com", "password", "gin", termsAgreementDtos,
+            Provider.EMAIL, "1");
 
         // then
         verify(memberJpaRepository, times(1)).save(any(Member.class));
@@ -133,7 +134,7 @@ class MemberServiceTest {
         when(termsJpaRepository.findById(anyLong())).thenReturn(Optional.of(terms));
         // then
         assertThatThrownBy(() -> memberService.signUp("test@test.com", "password", "gin",
-            requestTermsAgreementDtos))
+            requestTermsAgreementDtos, Provider.EMAIL, "1"))
             .isInstanceOf(CustomException.class)
             .hasMessage(ResponseCode.TERMS_MANDATORY_NOT_AGREED.getMessage());
     }


### PR DESCRIPTION
## 작업

1. 회원가입 API 주석 추가하였습니다.

2. 기존 회원가입이 이메일 회원가입만 가능하여 공통화 진행하였습니다
    * Request에서 Provider, ProviderId를 입력받습니다.
    * 변경에 맞춰 테스트 코드도 변경하였습니다.
  
3. 이메일 중복 API에서 이메일이 비어있는 값인지 확인하는 로직 위치를 컨트롤러에서 서비스로 위치 변경하였습니다.

## 참고 사항

## 관련 이슈
- #2
