### PR TITLE
FEAT, REFACTOR, FIX : 휴대전화 인증 기능 변경, 제약 사항 수정

### DIFF
--- a/src/main/java/com/zb/fresh_api/api/service/SmsService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/SmsService.java
@@ -43,7 +43,7 @@ public class SmsService {
         }
         if (certificationCode.equals(smsCertification)) {
             // TODO 문자 인증 성공 시 로직 구현
-             System.out.println("문자 인증 성공~");
+//             System.out.println("문자 인증 성공~");
         } else {
             throw new CustomException(ResponseCode.CERTIFICATION_CODE_NOT_CORRECT);
         }

--- a/src/main/java/com/zb/fresh_api/api/utils/SmsUtil.java
+++ b/src/main/java/com/zb/fresh_api/api/utils/SmsUtil.java
@@ -1,8 +1,12 @@
 package com.zb.fresh_api.api.utils;
 
 
+import static com.zb.fresh_api.common.constants.SmsConstants.random;
+
+import com.zb.fresh_api.common.constants.SmsConstants;
+import com.zb.fresh_api.common.exception.CustomException;
+import com.zb.fresh_api.common.exception.ResponseCode;
 import jakarta.annotation.PostConstruct;
-import java.security.SecureRandom;
 import lombok.RequiredArgsConstructor;
 import net.nurigo.sdk.NurigoApp;
 import net.nurigo.sdk.message.model.Message;
@@ -29,23 +33,16 @@ public class SmsUtil {
 
     DefaultMessageService messageService;
 
-    private static final String CHAR_LOWER = "abcdefghijklmnopqrstuvwxyz";
-    private static final String CHAR_UPPER = CHAR_LOWER.toUpperCase();
-    private static final String NUMBER = "0123456789";
-    private static final String DATA_FOR_RANDOM_STRING = CHAR_LOWER + CHAR_UPPER + NUMBER;
-    private static final SecureRandom random = new SecureRandom();
-    private static final int CODE_LENGTH = 6;
-
     @PostConstruct
     private void init() {
         this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, apiUrl);
     }
 
     public String generateRandomString() {
-        StringBuilder sb = new StringBuilder(CODE_LENGTH);
-        for (int i = 0; i < CODE_LENGTH; i++) {
-            int rndCharAt = random.nextInt(DATA_FOR_RANDOM_STRING.length());
-            char rndChar = DATA_FOR_RANDOM_STRING.charAt(rndCharAt);
+        StringBuilder sb = new StringBuilder(SmsConstants.CODE_LENGTH);
+        for (int i = 0; i < SmsConstants.CODE_LENGTH; i++) {
+            int rndCharAt = random.nextInt(SmsConstants.DATA_FOR_RANDOM_STRING.length());
+            char rndChar = SmsConstants.DATA_FOR_RANDOM_STRING.charAt(rndCharAt);
             sb.append(rndChar);
         }
 
@@ -58,7 +55,11 @@ public class SmsUtil {
         message.setFrom(fromNumber);
         message.setTo(toNumber);
         message.setText("[Fresh 2 you] \n" + "본인확인 인증번호는 " + certificationCode + "입니다.");
-        messageService.sendOne(new SingleMessageSendingRequest(message));
+        try {
+            messageService.sendOne(new SingleMessageSendingRequest(message));
+        }catch (Exception e) {
+            throw new CustomException(ResponseCode.NOT_ENOUGH_BALANCE);
+        }
     }
 
 }

--- a/src/main/java/com/zb/fresh_api/api/utils/SmsUtil.java
+++ b/src/main/java/com/zb/fresh_api/api/utils/SmsUtil.java
@@ -41,11 +41,10 @@ public class SmsUtil {
     public String generateRandomString() {
         StringBuilder sb = new StringBuilder(SmsConstants.CODE_LENGTH);
         for (int i = 0; i < SmsConstants.CODE_LENGTH; i++) {
-            int rndCharAt = random.nextInt(SmsConstants.DATA_FOR_RANDOM_STRING.length());
-            char rndChar = SmsConstants.DATA_FOR_RANDOM_STRING.charAt(rndCharAt);
+            int rndCharAt = random.nextInt(SmsConstants.NUMBER.length());
+            char rndChar = SmsConstants.NUMBER.charAt(rndCharAt);
             sb.append(rndChar);
         }
-
         return sb.toString();
     }
 

--- a/src/main/java/com/zb/fresh_api/common/constants/SmsConstants.java
+++ b/src/main/java/com/zb/fresh_api/common/constants/SmsConstants.java
@@ -1,0 +1,16 @@
+package com.zb.fresh_api.common.constants;
+
+import java.security.SecureRandom;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SmsConstants {
+    public static final String CHAR_LOWER = "abcdefghijklmnopqrstuvwxyz";
+    public static final String CHAR_UPPER = CHAR_LOWER.toUpperCase();
+    public static final String NUMBER = "0123456789";
+    public static final String DATA_FOR_RANDOM_STRING = CHAR_LOWER + CHAR_UPPER + NUMBER;
+    public static final SecureRandom random = new SecureRandom();
+    public static final int CODE_LENGTH = 6;
+
+}

--- a/src/main/java/com/zb/fresh_api/common/constants/SmsConstants.java
+++ b/src/main/java/com/zb/fresh_api/common/constants/SmsConstants.java
@@ -6,10 +6,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SmsConstants {
-    public static final String CHAR_LOWER = "abcdefghijklmnopqrstuvwxyz";
-    public static final String CHAR_UPPER = CHAR_LOWER.toUpperCase();
     public static final String NUMBER = "0123456789";
-    public static final String DATA_FOR_RANDOM_STRING = CHAR_LOWER + CHAR_UPPER + NUMBER;
     public static final SecureRandom random = new SecureRandom();
     public static final int CODE_LENGTH = 6;
 

--- a/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
+++ b/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
@@ -61,7 +61,8 @@ public enum ResponseCode {
      */
     EXCEEDED_CERTIFICATION_ATTEMPS("1400", "30분 내에 인증 요청 횟수를 초과했습니다."),
     CERTIFICATION_NOT_FOUND("1401", "인증 유효시간을 초과했습니다"),
-    CERTIFICATION_CODE_NOT_CORRECT("1402", "인증 코드가 일치하지 않습니다")
+    CERTIFICATION_CODE_NOT_CORRECT("1402", "인증 코드가 일치하지 않습니다"),
+    NOT_ENOUGH_BALANCE("1403", "서버 관리자에게 문의하세요")
     ;
 
     private final String code;

--- a/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
+++ b/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
@@ -59,7 +59,7 @@ public enum ResponseCode {
     /**
      * SMS (1400 ~ 1500)
      */
-    EXCEEDED_CERTIFICATION_ATTEMPS("1400", "30분 내에 인증 요청 횟수를 초과했습니다."),
+    EXCEEDED_CERTIFICATION_ATTEMPS("1400", "하루 인증 요청 횟수를 초과했습니다."),
     CERTIFICATION_NOT_FOUND("1401", "인증 유효시간을 초과했습니다"),
     CERTIFICATION_CODE_NOT_CORRECT("1402", "인증 코드가 일치하지 않습니다"),
     NOT_ENOUGH_BALANCE("1403", "서버 관리자에게 문의하세요")


### PR DESCRIPTION
## 작업

1. coolsms 잔액이 부족한 경우의 에러 코드 추가하였습니다. 이 경우 클라이언트에게 직접 부족하다고 설명해주는 건 불필요하다고 생각해서 message를 "서버 관리자에게 문의하세요"로 넣었습니다.

2. 휴대전화 인증 시 보내는 조합을 SmsConstants로 따로 분리하여 관리하도록 변경하였습니다.

3. 기존에는 휴대전화 인증 코드의 조합을 영어 대문자, 소문자, 숫자로 하였으나 @JIHU96님이 의견 주시어 좀 더 사용하기 편리하게 숫자로만 인증 코드를 조합하도록 수정하였습니다.

4. 임의로 걸어둔 제약 사항을 수정하였습니다
* 인증 유효시간 3분, 하루 최대 5번 인증가능

## 참고 사항

## 관련 이슈
- #8
