### PR TITLE
FEAT : 상품 관련 API 추가 

### DIFF
--- a/src/main/java/com/zb/fresh_api/api/controller/Auth/SmsAuthController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/Auth/SmsAuthController.java
@@ -1,12 +1,12 @@
 package com.zb.fresh_api.api.controller.Auth;
 
+import com.zb.fresh_api.api.annotation.LoginMember;
 import com.zb.fresh_api.api.service.SmsService;
 import com.zb.fresh_api.common.exception.ResponseCode;
 import com.zb.fresh_api.common.response.ApiResponse;
+import com.zb.fresh_api.domain.entity.member.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,25 +26,23 @@ public class SmsAuthController {
     private final SmsService smsService;
 
     @Operation(
-        summary = "인증 문자 전송",
+        summary = "판매자 인증 문자 전송",
         description = "입력한 휴대전화로 인증번호를 전송합니다"
     )
     @GetMapping
-    public ResponseEntity<ApiResponse<Void>> sendVerificationCode(@Valid @Pattern(regexp="(^$|[0-9]{10})")
-    @RequestParam String phoneNumber) {
+    public ResponseEntity<ApiResponse<Void>> sendVerificationCode(@RequestParam String phoneNumber) {
         smsService.sendSms(phoneNumber);
         return ApiResponse.success(ResponseCode.SUCCESS);
     }
 
     @Operation(
-        summary = "인증 코드 인증",
+        summary = "판매자 인증 코드 인증",
         description = "휴대전화로 온 인증코드를 통해 인증합니다"
     )
     @GetMapping("/verify")
-    public ResponseEntity<ApiResponse<Void>> verifySmsCode(@Valid @Pattern(regexp="(^$|[0-9]{10})")
-    @RequestParam String phoneNumber,
-        @RequestParam String verificationCode) {
-        smsService.verifyCode(phoneNumber, verificationCode);
+    public ResponseEntity<ApiResponse<Void>> verifySmsCode(@RequestParam String phoneNumber,
+        @RequestParam String verificationCode, @LoginMember Member member) {
+        smsService.verifyCode(phoneNumber, verificationCode, member);
         return ApiResponse.success(ResponseCode.SUCCESS);
     }
 }

--- a/src/main/java/com/zb/fresh_api/api/controller/CategoryController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/CategoryController.java
@@ -1,0 +1,35 @@
+package com.zb.fresh_api.api.controller;
+
+
+import com.zb.fresh_api.api.dto.response.GetAllCategoryResponse;
+import com.zb.fresh_api.api.service.CategoryService;
+import com.zb.fresh_api.common.exception.ResponseCode;
+import com.zb.fresh_api.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+    name = "카테고리 API",
+    description = "카테고리 관련 API"
+)
+@RestController
+@RequestMapping("/v1/api/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+    private  final CategoryService categoryService;
+
+    @Operation(
+        summary = "",
+        description = "카테고리 선택 시 사용할 API 입니다"
+    )
+    @GetMapping()
+    public ResponseEntity<ApiResponse<GetAllCategoryResponse>> getAllCategories() {
+        GetAllCategoryResponse response = categoryService.getAllCategories();
+        return ApiResponse.success(ResponseCode.SUCCESS,response);
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/controller/ProductController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/ProductController.java
@@ -1,0 +1,41 @@
+package com.zb.fresh_api.api.controller;
+
+import com.zb.fresh_api.api.annotation.LoginMember;
+import com.zb.fresh_api.api.dto.request.AddProductRequest;
+import com.zb.fresh_api.api.dto.response.AddProductResponse;
+import com.zb.fresh_api.api.service.ProductService;
+import com.zb.fresh_api.common.exception.ResponseCode;
+import com.zb.fresh_api.common.response.ApiResponse;
+import com.zb.fresh_api.domain.entity.member.Member;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+    name = "상품 API",
+    description = "상품 관련 API"
+)
+@RestController
+@RequestMapping("/v1/api/products")
+@RequiredArgsConstructor
+public class ProductController {
+    private final ProductService productService;
+
+
+    @Operation(
+        summary = "상품 등록",
+        description = "상품을 등록합니다."
+    )
+    @PostMapping
+    public ResponseEntity<ApiResponse<AddProductResponse>> addProduct(@Valid @RequestBody
+        AddProductRequest request, @LoginMember Member member) {
+        AddProductResponse storedProductId = productService.addProduct(request, member);
+        return ApiResponse.success(ResponseCode.SUCCESS, storedProductId );
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/controller/ProductController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/ProductController.java
@@ -2,7 +2,9 @@ package com.zb.fresh_api.api.controller;
 
 import com.zb.fresh_api.api.annotation.LoginMember;
 import com.zb.fresh_api.api.dto.request.AddProductRequest;
+import com.zb.fresh_api.api.dto.request.GetProductDetailRequest;
 import com.zb.fresh_api.api.dto.response.AddProductResponse;
+import com.zb.fresh_api.api.dto.response.GetProductDetailResponse;
 import com.zb.fresh_api.api.service.ProductService;
 import com.zb.fresh_api.common.exception.ResponseCode;
 import com.zb.fresh_api.common.response.ApiResponse;
@@ -12,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -41,4 +44,16 @@ public class ProductController {
         AddProductResponse storedProductId = productService.addProduct(request, member, image);
         return ApiResponse.success(ResponseCode.SUCCESS, storedProductId );
     }
+
+
+    @Operation(
+        summary = "상품 상세 조회",
+        description = "상품 ID를 통해 상품을 상세 조회합니다."
+    )
+    @GetMapping()
+    public ResponseEntity<ApiResponse<GetProductDetailResponse>> getProduct(GetProductDetailRequest request) {
+        GetProductDetailResponse productDetail = productService.getProductDetail(request);
+        return ApiResponse.success(ResponseCode.SUCCESS, productDetail);
+    }
+
 }

--- a/src/main/java/com/zb/fresh_api/api/controller/ProductController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/ProductController.java
@@ -3,18 +3,24 @@ package com.zb.fresh_api.api.controller;
 import com.zb.fresh_api.api.annotation.LoginMember;
 import com.zb.fresh_api.api.dto.request.AddProductRequest;
 import com.zb.fresh_api.api.dto.request.GetProductDetailRequest;
+import com.zb.fresh_api.api.dto.request.UpdateProductRequest;
 import com.zb.fresh_api.api.dto.response.AddProductResponse;
 import com.zb.fresh_api.api.dto.response.GetProductDetailResponse;
+import com.zb.fresh_api.api.dto.response.UpdateProductResponse;
 import com.zb.fresh_api.api.service.ProductService;
 import com.zb.fresh_api.common.exception.ResponseCode;
 import com.zb.fresh_api.common.response.ApiResponse;
 import com.zb.fresh_api.domain.entity.member.Member;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -55,5 +61,21 @@ public class ProductController {
         GetProductDetailResponse productDetail = productService.getProductDetail(request);
         return ApiResponse.success(ResponseCode.SUCCESS, productDetail);
     }
+
+    @Operation(
+        summary = "상품 수정",
+        description = "상품 수정을 위한 API입니다."
+    )
+    @PatchMapping(value = "/{productId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<UpdateProductResponse>> updateProduct(
+        @PathVariable(name = "productId") Long productId,
+        @Parameter(hidden = true) @LoginMember Member loginMember,
+        @Parameter @RequestPart(value = "request", required = false) UpdateProductRequest request,
+        @Parameter @RequestPart(value = "image",required = false) MultipartFile image) {
+        UpdateProductResponse updateProductResponse = productService.updateProduct(productId,
+            request, image, loginMember);
+        return ApiResponse.success(ResponseCode.SUCCESS,updateProductResponse);
+    }
+
 
 }

--- a/src/main/java/com/zb/fresh_api/api/controller/ProductController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/ProductController.java
@@ -2,9 +2,11 @@ package com.zb.fresh_api.api.controller;
 
 import com.zb.fresh_api.api.annotation.LoginMember;
 import com.zb.fresh_api.api.dto.request.AddProductRequest;
+import com.zb.fresh_api.api.dto.request.DeleteProductRequest;
 import com.zb.fresh_api.api.dto.request.GetProductDetailRequest;
 import com.zb.fresh_api.api.dto.request.UpdateProductRequest;
 import com.zb.fresh_api.api.dto.response.AddProductResponse;
+import com.zb.fresh_api.api.dto.response.DeleteProductResponse;
 import com.zb.fresh_api.api.dto.response.GetProductDetailResponse;
 import com.zb.fresh_api.api.dto.response.UpdateProductResponse;
 import com.zb.fresh_api.api.service.ProductService;
@@ -14,15 +16,14 @@ import com.zb.fresh_api.domain.entity.member.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,10 +45,10 @@ public class ProductController {
         description = "상품을 등록합니다."
     )
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<AddProductResponse>> addProduct(@Valid @RequestBody
-        @Parameter @RequestPart(value = "request", required = true) AddProductRequest request,
+    public ResponseEntity<ApiResponse<AddProductResponse>> addProduct(
         @Parameter(hidden = true)@LoginMember Member member,
-        @RequestPart(value = "image", required = false) MultipartFile image) {
+        @Parameter @RequestPart(value = "request", required = true) AddProductRequest request,
+        @Parameter @RequestPart(value = "image", required = false) MultipartFile image) {
         AddProductResponse storedProductId = productService.addProduct(request, member, image);
         return ApiResponse.success(ResponseCode.SUCCESS, storedProductId );
     }
@@ -78,5 +79,17 @@ public class ProductController {
         return ApiResponse.success(ResponseCode.SUCCESS,updateProductResponse);
     }
 
+
+    @Operation(
+        summary = "상품 삭제",
+        description = "상품 삭제를 위한 API입니다."
+    )
+    @DeleteMapping
+    public ResponseEntity<ApiResponse<DeleteProductResponse>> deleteProduct(DeleteProductRequest request,
+        @Parameter(hidden = true) @LoginMember Member member) {
+        DeleteProductResponse deleteProductId = productService.deleteProduct(request, member);
+        return ApiResponse.success(ResponseCode.SUCCESS,deleteProductId);
+
+    }
 
 }

--- a/src/main/java/com/zb/fresh_api/api/controller/ProductController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/ProductController.java
@@ -15,7 +15,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(
     name = "상품 API",
@@ -34,8 +36,9 @@ public class ProductController {
     )
     @PostMapping
     public ResponseEntity<ApiResponse<AddProductResponse>> addProduct(@Valid @RequestBody
-        AddProductRequest request, @LoginMember Member member) {
-        AddProductResponse storedProductId = productService.addProduct(request, member);
+        AddProductRequest request, @LoginMember Member member,
+        @RequestPart(value = "image", required = false) MultipartFile image) {
+        AddProductResponse storedProductId = productService.addProduct(request, member, image);
         return ApiResponse.success(ResponseCode.SUCCESS, storedProductId );
     }
 }

--- a/src/main/java/com/zb/fresh_api/api/controller/ProductController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/ProductController.java
@@ -43,9 +43,10 @@ public class ProductController {
         summary = "상품 등록",
         description = "상품을 등록합니다."
     )
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<AddProductResponse>> addProduct(@Valid @RequestBody
-        AddProductRequest request, @LoginMember Member member,
+        @Parameter @RequestPart(value = "request", required = true) AddProductRequest request,
+        @Parameter(hidden = true)@LoginMember Member member,
         @RequestPart(value = "image", required = false) MultipartFile image) {
         AddProductResponse storedProductId = productService.addProduct(request, member, image);
         return ApiResponse.success(ResponseCode.SUCCESS, storedProductId );

--- a/src/main/java/com/zb/fresh_api/api/converter/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/com/zb/fresh_api/api/converter/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,33 @@
+package com.zb.fresh_api.api.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Type;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    /**
+     * Converter for support http request with header Content-Type: multipart/form-data
+     */
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/converter/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/com/zb/fresh_api/api/converter/MultipartJackson2HttpMessageConverter.java
@@ -9,9 +9,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
 
-    /**
-     * Converter for support http request with header Content-Type: multipart/form-data
-     */
     public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
         super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
     }

--- a/src/main/java/com/zb/fresh_api/api/dto/request/AddProductRequest.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/request/AddProductRequest.java
@@ -1,0 +1,25 @@
+package com.zb.fresh_api.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+@Schema(description = "제품 등록 요청")
+public record AddProductRequest(
+
+    @NotEmpty(message = "제품 이름이 누락 되었습니다.")
+    String name,
+
+    @NotNull(message = "재고가 누락 되었습니다.")
+    int quantity,
+
+    @NotEmpty(message = "제품 설명이 누락되었습니다.")
+    String description,
+
+    @NotNull(message = "가격이 누락되었습니다.")
+    BigDecimal price,
+
+    @NotNull
+    Long categoryId
+) {}

--- a/src/main/java/com/zb/fresh_api/api/dto/request/DeleteProductRequest.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/request/DeleteProductRequest.java
@@ -1,0 +1,11 @@
+package com.zb.fresh_api.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "상품 삭제 요청")
+public record DeleteProductRequest(
+    @Schema(description = "삭제할 상품 ID")
+    Long productId
+) {
+
+}

--- a/src/main/java/com/zb/fresh_api/api/dto/request/GetProductDetailRequest.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/request/GetProductDetailRequest.java
@@ -1,0 +1,10 @@
+package com.zb.fresh_api.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record GetProductDetailRequest(
+    @Schema(description = "제품 ID")
+    @NotNull
+    Long productId
+) {}

--- a/src/main/java/com/zb/fresh_api/api/dto/request/UpdateProductRequest.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/request/UpdateProductRequest.java
@@ -1,0 +1,22 @@
+package com.zb.fresh_api.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+
+@Schema(description = "상품 수정 요청")
+public record UpdateProductRequest (
+    @Schema(description = "상품명")
+    String name,
+
+    @Schema(description = "상품 설명")
+    String description,
+
+    @Schema(description = "재고")
+    Integer quantity,
+
+    @Schema(description = "가격")
+    BigDecimal price,
+
+    @Schema(description = "카테고리 ID")
+    Long categoryId
+){}

--- a/src/main/java/com/zb/fresh_api/api/dto/response/AddProductResponse.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/response/AddProductResponse.java
@@ -1,0 +1,16 @@
+package com.zb.fresh_api.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "제품 등록 응답")
+public record AddProductResponse (
+    @Schema(description = "제품 ID")
+    Long id,
+    
+    @Schema(description = "제품 이름")
+    String name,
+    
+    @Schema(description = "제품 등록 시간")
+    LocalDateTime createdAt
+){}

--- a/src/main/java/com/zb/fresh_api/api/dto/response/CategoryDto.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/response/CategoryDto.java
@@ -1,0 +1,43 @@
+package com.zb.fresh_api.api.dto.response;
+
+import com.zb.fresh_api.domain.entity.category.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record CategoryDto (
+    @Schema(description = "카테고리 ID")
+    Long categoryId,
+    @Schema(description = "카테고리 이름")
+    String categoryName,
+    @Schema(description = "하위 카테고리 목록")
+    List<SubCategoryDto> subCategories) {
+    public static CategoryDto fromCategory(Category category, List<SubCategoryDto> subCategories) {
+        return new CategoryDto(
+            category.getId(),
+            category.getName(),
+            subCategories
+        );
+    }
+
+    public static List<CategoryDto> fromCategories(List<Category> categories) {
+        return getParentCategories(categories).stream()
+            .map(parentCategory -> {
+                List<SubCategoryDto> subCategories = getSubCategories(categories, parentCategory.getId());
+                return fromCategory(parentCategory, subCategories);
+            })
+            .collect(Collectors.toList());
+    }
+    private static List<Category> getParentCategories(List<Category> categories) {
+        return categories.stream()
+            .filter(category -> category.getParent() == null) // 상위 카테고리만 필터링
+            .collect(Collectors.toList());
+    }
+
+    private static List<SubCategoryDto> getSubCategories(List<Category> categories, Long parentId) {
+        return categories.stream()
+            .filter(category -> category.getParent() != null && category.getParent().getId().equals(parentId))
+            .map(subCategory -> new SubCategoryDto(subCategory.getId(), subCategory.getName()))
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/dto/response/DeleteProductResponse.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/response/DeleteProductResponse.java
@@ -1,0 +1,9 @@
+package com.zb.fresh_api.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "상품 삭제 응답")
+public record DeleteProductResponse(
+    @Schema(description = "삭제된 상품 ID")
+    Long productId
+) {}

--- a/src/main/java/com/zb/fresh_api/api/dto/response/GetAllCategoryResponse.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/response/GetAllCategoryResponse.java
@@ -1,0 +1,7 @@
+package com.zb.fresh_api.api.dto.response;
+
+import java.util.List;
+
+public record GetAllCategoryResponse(List<CategoryDto> categories) {
+
+}

--- a/src/main/java/com/zb/fresh_api/api/dto/response/GetProductDetailResponse.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/response/GetProductDetailResponse.java
@@ -1,0 +1,35 @@
+package com.zb.fresh_api.api.dto.response;
+
+import com.zb.fresh_api.domain.entity.product.Product;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+
+@Schema(description = "제품 상세 조회 응답")
+public record GetProductDetailResponse (
+    @Schema(description = "상품명")
+    String productName,
+
+    @Schema(description = "판매자명")
+    String sellerName,
+
+    @Schema(description = "가격")
+    BigDecimal price,
+
+    @Schema(description = "재고")
+    int quantity,
+
+    @Schema(description = "제품 설명")
+    String description,
+
+    @Schema(description = "제품 url")
+    String imageUrl
+){
+
+    public static GetProductDetailResponse fromEntity(Product product) {
+        return new GetProductDetailResponse(
+            product.getName(), product.getMember().getNickname(),
+            product.getPrice(), product.getQuantity(), product.getDescription(),
+            product.getProductImage()
+        );
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/dto/response/GetProductDetailResponse.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/response/GetProductDetailResponse.java
@@ -6,6 +6,9 @@ import java.math.BigDecimal;
 
 @Schema(description = "제품 상세 조회 응답")
 public record GetProductDetailResponse (
+    @Schema(description = "상품 ID")
+    Long productId,
+
     @Schema(description = "상품명")
     String productName,
 
@@ -26,7 +29,7 @@ public record GetProductDetailResponse (
 ){
 
     public static GetProductDetailResponse fromEntity(Product product) {
-        return new GetProductDetailResponse(
+        return new GetProductDetailResponse(product.getId(),
             product.getName(), product.getMember().getNickname(),
             product.getPrice(), product.getQuantity(), product.getDescription(),
             product.getProductImage()

--- a/src/main/java/com/zb/fresh_api/api/dto/response/SubCategoryDto.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/response/SubCategoryDto.java
@@ -1,0 +1,9 @@
+package com.zb.fresh_api.api.dto.response;
+
+import com.zb.fresh_api.domain.entity.category.Category;
+
+public record SubCategoryDto (Long categoryId, String categoryName){
+    public static SubCategoryDto fromCategory(Category category) {
+        return new SubCategoryDto(category.getId(), category.getName());
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/dto/response/SubCategoryDto.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/response/SubCategoryDto.java
@@ -1,9 +1,3 @@
 package com.zb.fresh_api.api.dto.response;
 
-import com.zb.fresh_api.domain.entity.category.Category;
-
-public record SubCategoryDto (Long categoryId, String categoryName){
-    public static SubCategoryDto fromCategory(Category category) {
-        return new SubCategoryDto(category.getId(), category.getName());
-    }
-}
+public record SubCategoryDto(Long categoryId, String categoryName) {}

--- a/src/main/java/com/zb/fresh_api/api/dto/response/UpdateProductResponse.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/response/UpdateProductResponse.java
@@ -1,0 +1,9 @@
+package com.zb.fresh_api.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "상품 수정 응답")
+public record UpdateProductResponse (
+    @Schema(description = "상품 ID")
+    Long productId
+){}

--- a/src/main/java/com/zb/fresh_api/api/service/CategoryService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/CategoryService.java
@@ -1,0 +1,37 @@
+package com.zb.fresh_api.api.service;
+
+import com.zb.fresh_api.api.dto.response.CategoryDto;
+import com.zb.fresh_api.api.dto.response.GetAllCategoryResponse;
+import com.zb.fresh_api.api.dto.response.SubCategoryDto;
+import com.zb.fresh_api.domain.entity.category.Category;
+import com.zb.fresh_api.domain.repository.reader.CategoryReader;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+    private final CategoryReader categoryReader;
+
+    public GetAllCategoryResponse getAllCategories() {
+        List<Category> categories = categoryReader.findAll();
+        List<CategoryDto> categoryDTOs = CategoryDto.fromCategories(categories);
+
+        return new GetAllCategoryResponse(categoryDTOs);
+    }
+
+    private List<Category> getParentCategories(List<Category> categories) {
+        return categories.stream()
+            .filter(category -> category.getParent() == null) // 상위 카테고리만 필터링
+            .collect(Collectors.toList());
+    }
+
+    private List<SubCategoryDto> getSubCategories(List<Category> categories, Long parentId) {
+        return categories.stream()
+            .filter(category -> category.getParent() != null && category.getParent().getId().equals(parentId))
+            .map(subCategory -> new SubCategoryDto(subCategory.getId(), subCategory.getName()))
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/service/CategoryService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/CategoryService.java
@@ -2,11 +2,9 @@ package com.zb.fresh_api.api.service;
 
 import com.zb.fresh_api.api.dto.response.CategoryDto;
 import com.zb.fresh_api.api.dto.response.GetAllCategoryResponse;
-import com.zb.fresh_api.api.dto.response.SubCategoryDto;
 import com.zb.fresh_api.domain.entity.category.Category;
 import com.zb.fresh_api.domain.repository.reader.CategoryReader;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,18 +18,5 @@ public class CategoryService {
         List<CategoryDto> categoryDTOs = CategoryDto.fromCategories(categories);
 
         return new GetAllCategoryResponse(categoryDTOs);
-    }
-
-    private List<Category> getParentCategories(List<Category> categories) {
-        return categories.stream()
-            .filter(category -> category.getParent() == null) // 상위 카테고리만 필터링
-            .collect(Collectors.toList());
-    }
-
-    private List<SubCategoryDto> getSubCategories(List<Category> categories, Long parentId) {
-        return categories.stream()
-            .filter(category -> category.getParent() != null && category.getParent().getId().equals(parentId))
-            .map(subCategory -> new SubCategoryDto(subCategory.getId(), subCategory.getName()))
-            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/zb/fresh_api/api/service/ProductService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/ProductService.java
@@ -1,13 +1,16 @@
 package com.zb.fresh_api.api.service;
 
 import com.zb.fresh_api.api.dto.request.AddProductRequest;
+import com.zb.fresh_api.api.dto.request.GetProductDetailRequest;
 import com.zb.fresh_api.api.dto.response.AddProductResponse;
+import com.zb.fresh_api.api.dto.response.GetProductDetailResponse;
 import com.zb.fresh_api.common.exception.CustomException;
 import com.zb.fresh_api.common.exception.ResponseCode;
 import com.zb.fresh_api.domain.entity.category.Category;
 import com.zb.fresh_api.domain.entity.member.Member;
 import com.zb.fresh_api.domain.entity.product.Product;
 import com.zb.fresh_api.domain.repository.reader.CategoryReader;
+import com.zb.fresh_api.domain.repository.reader.ProductReader;
 import com.zb.fresh_api.domain.repository.writer.ProductWriter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +22,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class ProductService {
 
     private final ProductWriter productWriter;
+    private final ProductReader productReader;
     private final CategoryReader categoryReader;
     @Transactional
     public AddProductResponse addProduct(AddProductRequest request, Member member,
@@ -35,5 +39,12 @@ public class ProductService {
 
         Product storedProduct = productWriter.store(Product.create(request, category, member, profileImage));
         return new AddProductResponse(storedProduct.getId(), storedProduct.getName(), storedProduct.getCreatedAt());
+    }
+
+    public GetProductDetailResponse getProductDetail(GetProductDetailRequest request) {
+        Product product = productReader.findById(request.productId())
+            .orElseThrow(() -> new CustomException(ResponseCode.PRODUCT_NOT_FOUND));
+
+        return GetProductDetailResponse.fromEntity(product);
     }
 }

--- a/src/main/java/com/zb/fresh_api/api/service/ProductService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/ProductService.java
@@ -2,16 +2,20 @@ package com.zb.fresh_api.api.service;
 
 import com.zb.fresh_api.api.dto.request.AddProductRequest;
 import com.zb.fresh_api.api.dto.request.GetProductDetailRequest;
+import com.zb.fresh_api.api.dto.request.UpdateProductRequest;
 import com.zb.fresh_api.api.dto.response.AddProductResponse;
 import com.zb.fresh_api.api.dto.response.GetProductDetailResponse;
+import com.zb.fresh_api.api.dto.response.UpdateProductResponse;
 import com.zb.fresh_api.common.exception.CustomException;
 import com.zb.fresh_api.common.exception.ResponseCode;
 import com.zb.fresh_api.domain.entity.category.Category;
 import com.zb.fresh_api.domain.entity.member.Member;
 import com.zb.fresh_api.domain.entity.product.Product;
 import com.zb.fresh_api.domain.repository.reader.CategoryReader;
+import com.zb.fresh_api.domain.repository.reader.MemberReader;
 import com.zb.fresh_api.domain.repository.reader.ProductReader;
 import com.zb.fresh_api.domain.repository.writer.ProductWriter;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +28,8 @@ public class ProductService {
     private final ProductWriter productWriter;
     private final ProductReader productReader;
     private final CategoryReader categoryReader;
+    private final MemberReader memberReader;
+
     @Transactional
     public AddProductResponse addProduct(AddProductRequest request, Member member,
         MultipartFile image) {
@@ -31,7 +37,7 @@ public class ProductService {
             throw new CustomException(ResponseCode.UNAUTHORIZED_ACCESS_EXCEPTION);
         }
         Category category = categoryReader.findById(request.categoryId()).orElseThrow(
-            () -> new CustomException(ResponseCode.CATEGORY_NOT_VALID)
+            () -> new CustomException(ResponseCode.CATEGORY_NOT_FOUND)
         );
 
         // TODO 1. 이미지 변환 (S3)
@@ -41,10 +47,49 @@ public class ProductService {
         return new AddProductResponse(storedProduct.getId(), storedProduct.getName(), storedProduct.getCreatedAt());
     }
 
-    public GetProductDetailResponse getProductDetail(GetProductDetailRequest request) {
+    @Transactional(readOnly = true)
+    public GetProductDetailResponse getProductDetail(final GetProductDetailRequest request) {
         Product product = productReader.findById(request.productId())
             .orElseThrow(() -> new CustomException(ResponseCode.PRODUCT_NOT_FOUND));
 
         return GetProductDetailResponse.fromEntity(product);
+    }
+
+    @Transactional
+    public UpdateProductResponse updateProduct(final Long productId, final UpdateProductRequest request, final MultipartFile imageRequest,
+        final Member loginMember) {
+        Product product = productReader.findById(productId)
+            .orElseThrow(() -> new CustomException(ResponseCode.PRODUCT_NOT_FOUND));
+
+        if(!Objects.equals(loginMember.getId(), product.getMember().getId())){
+            throw  new CustomException(ResponseCode.NOT_PRODUCT_OWNER);
+        }
+
+        if(memberReader.existActiveNickname(request.name())){
+            throw new CustomException(ResponseCode.NICKNAME_ALREADY_IN_USE);
+        }
+
+        final String newProfileImage = convertImage(imageRequest);
+        Category newCategory = findCategory(request.categoryId());
+        product.update(request, newProfileImage, newCategory);
+
+        return new UpdateProductResponse(product.getId());
+    }
+
+    // TODO 1. 이미지 변환 (S3)
+    private String convertImage(MultipartFile imageRequest) {
+        if (imageRequest != null && !imageRequest.isEmpty()) {
+            // 이미지 변환 로직 (예: S3 업로드)
+            return "newProfileImageUrl"; // 실제 변환된 이미지 URL을 반환
+        }
+        return null;
+    }
+
+    private Category findCategory(Long categoryId) {
+        if (categoryId != null) {
+            return categoryReader.findById(categoryId)
+                .orElseThrow(() -> new CustomException(ResponseCode.CATEGORY_NOT_FOUND));
+        }
+        return null;
     }
 }

--- a/src/main/java/com/zb/fresh_api/api/service/ProductService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/ProductService.java
@@ -1,0 +1,34 @@
+package com.zb.fresh_api.api.service;
+
+import com.zb.fresh_api.api.dto.request.AddProductRequest;
+import com.zb.fresh_api.api.dto.response.AddProductResponse;
+import com.zb.fresh_api.common.exception.CustomException;
+import com.zb.fresh_api.common.exception.ResponseCode;
+import com.zb.fresh_api.domain.entity.category.Category;
+import com.zb.fresh_api.domain.entity.member.Member;
+import com.zb.fresh_api.domain.entity.product.Product;
+import com.zb.fresh_api.domain.repository.reader.CategoryReader;
+import com.zb.fresh_api.domain.repository.writer.ProductWriter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductWriter productWriter;
+    private final CategoryReader categoryReader;
+    @Transactional
+    public AddProductResponse addProduct(AddProductRequest request, Member member) {
+        if (!member.isSeller()) {
+            throw new CustomException(ResponseCode.UNAUTHORIZED_ACCESS_EXCEPTION);
+        }
+        Category category = categoryReader.findById(request.categoryId()).orElseThrow(
+            () -> new CustomException(ResponseCode.CATEGORY_NOT_VALID)
+        );
+
+        Product storedProduct = productWriter.store(Product.create(request, category, member));
+        return new AddProductResponse(storedProduct.getId(), storedProduct.getName(), storedProduct.getCreatedAt());
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/service/ProductService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/ProductService.java
@@ -12,6 +12,7 @@ import com.zb.fresh_api.domain.repository.writer.ProductWriter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -20,7 +21,8 @@ public class ProductService {
     private final ProductWriter productWriter;
     private final CategoryReader categoryReader;
     @Transactional
-    public AddProductResponse addProduct(AddProductRequest request, Member member) {
+    public AddProductResponse addProduct(AddProductRequest request, Member member,
+        MultipartFile image) {
         if (!member.isSeller()) {
             throw new CustomException(ResponseCode.UNAUTHORIZED_ACCESS_EXCEPTION);
         }
@@ -28,7 +30,10 @@ public class ProductService {
             () -> new CustomException(ResponseCode.CATEGORY_NOT_VALID)
         );
 
-        Product storedProduct = productWriter.store(Product.create(request, category, member));
+        // TODO 1. 이미지 변환 (S3)
+        final String profileImage = null;
+
+        Product storedProduct = productWriter.store(Product.create(request, category, member, profileImage));
         return new AddProductResponse(storedProduct.getId(), storedProduct.getName(), storedProduct.getCreatedAt());
     }
 }

--- a/src/main/java/com/zb/fresh_api/api/service/ProductService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/ProductService.java
@@ -15,7 +15,6 @@ import com.zb.fresh_api.domain.entity.member.Member;
 import com.zb.fresh_api.domain.entity.product.Product;
 import com.zb.fresh_api.domain.entity.product.ProductSnapshot;
 import com.zb.fresh_api.domain.repository.reader.CategoryReader;
-import com.zb.fresh_api.domain.repository.reader.MemberReader;
 import com.zb.fresh_api.domain.repository.reader.ProductReader;
 import com.zb.fresh_api.domain.repository.writer.ProductSnapshotWriter;
 import com.zb.fresh_api.domain.repository.writer.ProductWriter;
@@ -32,7 +31,6 @@ public class ProductService {
     private final ProductWriter productWriter;
     private final ProductReader productReader;
     private final CategoryReader categoryReader;
-    private final MemberReader memberReader;
     private final ProductSnapshotWriter productSnapshotWriter;
 
     @Transactional
@@ -70,10 +68,6 @@ public class ProductService {
             throw  new CustomException(ResponseCode.NOT_PRODUCT_OWNER);
         }
 
-        if(memberReader.existActiveNickname(request.name())){
-            throw new CustomException(ResponseCode.NICKNAME_ALREADY_IN_USE);
-        }
-
         productSnapshotWriter.store(ProductSnapshot.create(product));
 
         final String newProfileImage = convertImage(imageRequest);
@@ -106,7 +100,7 @@ public class ProductService {
         Product product = productReader.findById(request.productId()).orElseThrow(
             () -> new CustomException(ResponseCode.PRODUCT_NOT_FOUND));
 
-        if(member.getId() != product.getMember().getId()){
+        if(!Objects.equals(member.getId(), product.getMember().getId())){
             throw new CustomException(ResponseCode.UNAUTHORIZED_ACCESS_EXCEPTION);
         }
 

--- a/src/main/java/com/zb/fresh_api/api/service/ProductService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/ProductService.java
@@ -11,9 +11,11 @@ import com.zb.fresh_api.common.exception.ResponseCode;
 import com.zb.fresh_api.domain.entity.category.Category;
 import com.zb.fresh_api.domain.entity.member.Member;
 import com.zb.fresh_api.domain.entity.product.Product;
+import com.zb.fresh_api.domain.entity.product.ProductSnapshot;
 import com.zb.fresh_api.domain.repository.reader.CategoryReader;
 import com.zb.fresh_api.domain.repository.reader.MemberReader;
 import com.zb.fresh_api.domain.repository.reader.ProductReader;
+import com.zb.fresh_api.domain.repository.writer.ProductSnapshotWriter;
 import com.zb.fresh_api.domain.repository.writer.ProductWriter;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +31,7 @@ public class ProductService {
     private final ProductReader productReader;
     private final CategoryReader categoryReader;
     private final MemberReader memberReader;
+    private final ProductSnapshotWriter productSnapshotWriter;
 
     @Transactional
     public AddProductResponse addProduct(AddProductRequest request, Member member,
@@ -69,9 +72,12 @@ public class ProductService {
             throw new CustomException(ResponseCode.NICKNAME_ALREADY_IN_USE);
         }
 
+        productSnapshotWriter.store(ProductSnapshot.create(product));
+
         final String newProfileImage = convertImage(imageRequest);
         Category newCategory = findCategory(request.categoryId());
         product.update(request, newProfileImage, newCategory);
+
 
         return new UpdateProductResponse(product.getId());
     }

--- a/src/main/java/com/zb/fresh_api/api/service/ProductService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/ProductService.java
@@ -1,9 +1,11 @@
 package com.zb.fresh_api.api.service;
 
 import com.zb.fresh_api.api.dto.request.AddProductRequest;
+import com.zb.fresh_api.api.dto.request.DeleteProductRequest;
 import com.zb.fresh_api.api.dto.request.GetProductDetailRequest;
 import com.zb.fresh_api.api.dto.request.UpdateProductRequest;
 import com.zb.fresh_api.api.dto.response.AddProductResponse;
+import com.zb.fresh_api.api.dto.response.DeleteProductResponse;
 import com.zb.fresh_api.api.dto.response.GetProductDetailResponse;
 import com.zb.fresh_api.api.dto.response.UpdateProductResponse;
 import com.zb.fresh_api.common.exception.CustomException;
@@ -97,5 +99,20 @@ public class ProductService {
                 .orElseThrow(() -> new CustomException(ResponseCode.CATEGORY_NOT_FOUND));
         }
         return null;
+    }
+
+//    @Transactional
+    public DeleteProductResponse deleteProduct(DeleteProductRequest request, Member member) {
+        Product product = productReader.findById(request.productId()).orElseThrow(
+            () -> new CustomException(ResponseCode.PRODUCT_NOT_FOUND));
+
+        if(member.getId() != product.getMember().getId()){
+            throw new CustomException(ResponseCode.UNAUTHORIZED_ACCESS_EXCEPTION);
+        }
+
+        Product.delete(product);
+        productWriter.store(product);
+        return new DeleteProductResponse(product.getId());
+
     }
 }

--- a/src/main/java/com/zb/fresh_api/api/service/SmsService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/SmsService.java
@@ -6,8 +6,12 @@ import com.zb.fresh_api.api.utils.RedisUtil;
 import com.zb.fresh_api.api.utils.SmsUtil;
 import com.zb.fresh_api.common.exception.CustomException;
 import com.zb.fresh_api.common.exception.ResponseCode;
+import com.zb.fresh_api.domain.entity.member.Member;
+import com.zb.fresh_api.domain.repository.reader.MemberReader;
+import com.zb.fresh_api.domain.repository.writer.MemberWriter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +19,8 @@ public class SmsService {
 
     private final RedisUtil redisUtil;
     private final SmsUtil smsUtil;
+    private final MemberReader memberReader;
+    private final MemberWriter memberWriter;
 
     /**
      * 문자 인증 코드 전송 로직 1. 현재 전화번호의 요청이 제한 횟수 이상 왔는지 검증
@@ -26,6 +32,11 @@ public class SmsService {
         if (redisUtil.hasExceededAttemptLimit(toNumber, VerificationType.PHONE)) {
             throw new CustomException(ResponseCode.EXCEEDED_VERIFICATION_ATTEMPS);
         }
+
+        if(memberReader.existsByPhone(toNumber)){
+            throw new CustomException(ResponseCode.PHONE_ALREADY_IN_USE);
+        }
+
         String verificationCode = VerificationCodeUtil.generateRandomString();
         smsUtil.sendVerificationCode(toNumber, verificationCode);
         redisUtil.saveVerificationCode(toNumber, verificationCode, VerificationType.PHONE);
@@ -38,14 +49,15 @@ public class SmsService {
      * 2. 인증 코드가 일치하면 성공 로직 구현(미정) 일치하지 않으면 에러 발생
      * 3. redis에서 휴대전화 관련 데이터 삭제
      */
-    public void verifyCode(String phone, String verificationCode) {
+    @Transactional
+    public void verifyCode(String phone, String verificationCode, Member member) {
         String findVerification = redisUtil.findSmsVerification(phone, VerificationType.PHONE);
         if (findVerification == null) {
             throw new CustomException(ResponseCode.VERIFICATION_NOT_FOUND);
         }
         if (verificationCode.equals(findVerification)) {
-            // TODO 문자 인증 성공 시 로직 구현
-//             System.out.println("문자 인증 성공~");
+            member.setMemberSeller(phone);
+            memberWriter.store(member);
         } else {
             throw new CustomException(ResponseCode.VERIFICATION_CODE_NOT_CORRECT);
         }

--- a/src/main/java/com/zb/fresh_api/api/utils/SmsUtil.java
+++ b/src/main/java/com/zb/fresh_api/api/utils/SmsUtil.java
@@ -1,7 +1,6 @@
 package com.zb.fresh_api.api.utils;
 
 
-import com.zb.fresh_api.common.constants.SmsConstants;
 import com.zb.fresh_api.common.exception.CustomException;
 import com.zb.fresh_api.common.exception.ResponseCode;
 import jakarta.annotation.PostConstruct;
@@ -13,7 +12,6 @@ import net.nurigo.sdk.message.service.DefaultMessageService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import static com.zb.fresh_api.common.constants.SmsConstants.random;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
+++ b/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
@@ -69,12 +69,13 @@ public enum ResponseCode {
     /**
      * Category (1500 ~ 1600)
      */
-    CATEGORY_NOT_VALID("1500", "카테고리를 찾을 수 없습니다."),
+    CATEGORY_NOT_FOUND("1500", "카테고리를 찾을 수 없습니다."),
 
     /**
      * Product (1600 ~ 1700)
      */
     PRODUCT_NOT_FOUND("1600", "상품을 찾을 수 없습니다"),
+    NOT_PRODUCT_OWNER("1601", "수정하려는 사용자가 판매자와 일치하지 않습니다.")
     ;
 
     private final String code;

--- a/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
+++ b/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
@@ -65,7 +65,7 @@ public enum ResponseCode {
     VERIFICATION_CODE_NOT_CORRECT("1402", "인증 코드가 일치하지 않습니다"),
     NOT_ENOUGH_BALANCE("1403", "서버 관리자에게 문의하세요"),
     GOOGLE_SMTP_ERROR("1404", "서버 관리자에게 문의하세요"),
-
+    PHONE_ALREADY_IN_USE("1405", "이미 사용중인 휴대전화 입니다"),
     /**
      * Category (1500 ~ 1600)
      */

--- a/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
+++ b/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
@@ -69,8 +69,12 @@ public enum ResponseCode {
     /**
      * Category (1500 ~ 1600)
      */
-    CATEGORY_NOT_VALID("1002", "카테고리를 찾을 수 없습니다."),
+    CATEGORY_NOT_VALID("1500", "카테고리를 찾을 수 없습니다."),
 
+    /**
+     * Product (1600 ~ 1700)
+     */
+    PRODUCT_NOT_FOUND("1600", "상품을 찾을 수 없습니다"),
     ;
 
     private final String code;

--- a/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
+++ b/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
@@ -46,6 +46,7 @@ public enum ResponseCode {
     NON_LOCKED_ACCOUNT("1203", "사용자 계정이 정지되었습니다."),
     DISABLE_ACCOUNT("1204", "사용자 계정은 비활성화 상태입니다."),
     EXPIRED_CREDENTIAL("1205", "사용자 인증 정보가 만료되었습니다."),
+    UNAUTHORIZED_ACCESS_EXCEPTION("1206", "사용자가 판매자가 아닙니다."),
 
     /**
      * Json Web Token (1300 ~ 1400)
@@ -63,7 +64,13 @@ public enum ResponseCode {
     VERIFICATION_NOT_FOUND("1401", "인증이 존재하지 않거나 인증 유효시간을 초과했습니다"),
     VERIFICATION_CODE_NOT_CORRECT("1402", "인증 코드가 일치하지 않습니다"),
     NOT_ENOUGH_BALANCE("1403", "서버 관리자에게 문의하세요"),
-    GOOGLE_SMTP_ERROR("1404", "서버 관리자에게 문의하세요")
+    GOOGLE_SMTP_ERROR("1404", "서버 관리자에게 문의하세요"),
+
+    /**
+     * Category (1500 ~ 1600)
+     */
+    CATEGORY_NOT_VALID("1002", "카테고리를 찾을 수 없습니다."),
+
     ;
 
     private final String code;

--- a/src/main/java/com/zb/fresh_api/domain/entity/category/Category.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/category/Category.java
@@ -1,0 +1,43 @@
+package com.zb.fresh_api.domain.entity.category;
+
+import com.zb.fresh_api.domain.entity.base.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(
+    name = "category"
+)
+public class Category extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", columnDefinition = "BIGINT UNSIGNED comment '고유 번호'")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id",nullable = true, columnDefinition = "BIGINT UNSIGNED comment '카테고리 부모 번호'")
+
+    private Category parent;
+
+    @Column(name="is_used", nullable = false, columnDefinition = "BOOLEAN comment '사용 여부'")
+    private Boolean isUsed;
+
+    @Column(name = "name", nullable = false, columnDefinition = "varchar(20) comment '카테고리명'")
+    private String name;
+}

--- a/src/main/java/com/zb/fresh_api/domain/entity/member/Member.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/member/Member.java
@@ -60,7 +60,7 @@ public class Member extends BaseTimeEntity {
     private LocalDateTime deletedAt;
 
     @Column(name = "is_seller", columnDefinition = "boolean comment '판매자 인증 여부'")
-    private boolean isSeller;
+    private boolean isSeller = false;
 
     @Column(name = "seller_verified_at", columnDefinition = "datetime comment '판매자 인증 일시'")
     private LocalDateTime sellerVerifiedAt;
@@ -83,6 +83,12 @@ public class Member extends BaseTimeEntity {
             return;
         }
         this.profileImage = profileImage;
+    }
+
+    public void setMemberSeller(String phone) {
+        this.phone = phone;
+        this.isSeller = true;
+        this.sellerVerifiedAt = LocalDateTime.now();
     }
 
 }

--- a/src/main/java/com/zb/fresh_api/domain/entity/member/Member.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/member/Member.java
@@ -59,6 +59,12 @@ public class Member extends BaseTimeEntity {
     @Column(name = "deleted_at", columnDefinition = "datetime comment '탈퇴 일시'")
     private LocalDateTime deletedAt;
 
+    @Column(name = "is_seller", columnDefinition = "boolean comment '판매자 인증 여부'")
+    private boolean isSeller;
+
+    @Column(name = "seller_verified_at", columnDefinition = "datetime comment '판매자 인증 일시'")
+    private LocalDateTime sellerVerifiedAt;
+
     public void updateProfile(final String nickname,
                               final String profileImage) {
         updateNickname(nickname);

--- a/src/main/java/com/zb/fresh_api/domain/entity/product/Product.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/product/Product.java
@@ -1,6 +1,8 @@
 package com.zb.fresh_api.domain.entity.product;
 
+import com.zb.fresh_api.api.dto.request.AddProductRequest;
 import com.zb.fresh_api.domain.entity.base.BaseTimeEntity;
+import com.zb.fresh_api.domain.entity.category.Category;
 import com.zb.fresh_api.domain.entity.member.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -38,9 +40,9 @@ public class Product extends BaseTimeEntity {
     @JoinColumn(name = "member_id", nullable = false, columnDefinition = "BIGINT UNSIGNED comment '회원 고유 번호'")
     private Member member;
 
-//    @OneToMany(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "category_id", nullable = false, columnDefinition = "BIGINT UNSIGNED comment '카테고리 고유 번호'")
-//    private Category category;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false, columnDefinition = "BIGINT UNSIGNED comment '카테고리 고유 번호'")
+    private Category category;
 
     @JoinColumn(name = "name", nullable = false, columnDefinition = "varchar(20)  comment '상품명'")
     private String name;
@@ -58,4 +60,14 @@ public class Product extends BaseTimeEntity {
     @Column(name = "deleted_at", columnDefinition = "datetime comment '삭제일'")
     private LocalDateTime deleted_at;
 
+    public static Product create(AddProductRequest request,Category category, Member member){
+        return Product.builder()
+            .member(member)
+            .category(category)
+            .name(request.name())
+            .description(request.description())
+            .quantity(request.quantity())
+            .price(request.price())
+            .build();
+    }
 }

--- a/src/main/java/com/zb/fresh_api/domain/entity/product/Product.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/product/Product.java
@@ -21,7 +21,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.LastModifiedDate;
 
 @Getter
 @Builder
@@ -60,7 +59,6 @@ public class Product extends BaseTimeEntity {
     @Column(name = "product_image", columnDefinition = "varchar(255) comment '상품 이미지'")
     private String productImage;
     
-    @LastModifiedDate
     @Column(name = "deleted_at", columnDefinition = "datetime comment '삭제일'")
     private LocalDateTime deleted_at;
 
@@ -83,5 +81,9 @@ public class Product extends BaseTimeEntity {
         if(request.quantity() != null) this.quantity = request.quantity();
         if(request.price() != null) this.price = request.price();
         if(productImageUrl != null) this.productImage = productImageUrl;
+    }
+
+    public static void delete(Product product){
+        product.deleted_at = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/zb/fresh_api/domain/entity/product/Product.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/product/Product.java
@@ -1,0 +1,61 @@
+package com.zb.fresh_api.domain.entity.product;
+
+import com.zb.fresh_api.domain.entity.base.BaseTimeEntity;
+import com.zb.fresh_api.domain.entity.member.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(
+    name = "product"
+)
+public class Product extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", columnDefinition = "BIGINT UNSIGNED comment '고유 번호'")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false, columnDefinition = "BIGINT UNSIGNED comment '회원 고유 번호'")
+    private Member member;
+
+//    @OneToMany(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "category_id", nullable = false, columnDefinition = "BIGINT UNSIGNED comment '카테고리 고유 번호'")
+//    private Category category;
+
+    @JoinColumn(name = "name", nullable = false, columnDefinition = "varchar(20)  comment '상품명'")
+    private String name;
+
+    @JoinColumn(name = "description", nullable = false, columnDefinition = "text  comment '상품설명'")
+    private String description;
+
+    @Column(name = "quantity", nullable = false, columnDefinition = "INT UNSIGNED comment '재고'")
+    private int quantity;
+
+    @Column(name = "price", nullable = false, precision = 10, scale = 2, columnDefinition = "DECIMAL(10,2) comment '가격'")
+    private BigDecimal price;
+
+    @LastModifiedDate
+    @Column(name = "deleted_at", columnDefinition = "datetime comment '삭제일'")
+    private LocalDateTime deleted_at;
+
+}

--- a/src/main/java/com/zb/fresh_api/domain/entity/product/Product.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/product/Product.java
@@ -1,6 +1,7 @@
 package com.zb.fresh_api.domain.entity.product;
 
 import com.zb.fresh_api.api.dto.request.AddProductRequest;
+import com.zb.fresh_api.api.dto.request.UpdateProductRequest;
 import com.zb.fresh_api.domain.entity.base.BaseTimeEntity;
 import com.zb.fresh_api.domain.entity.category.Category;
 import com.zb.fresh_api.domain.entity.member.Member;
@@ -73,5 +74,14 @@ public class Product extends BaseTimeEntity {
             .price(request.price())
             .productImage(productImage)
             .build();
+    }
+
+    public void update(UpdateProductRequest request, String productImageUrl, Category category){
+        if(category != null) this.category = category;
+        if(request.name() != null) this.name = request.name();
+        if(request.description() != null) this.description = request.description();
+        if(request.quantity() != null) this.quantity = request.quantity();
+        if(request.price() != null) this.price = request.price();
+        if(productImageUrl != null) this.productImage = productImageUrl;
     }
 }

--- a/src/main/java/com/zb/fresh_api/domain/entity/product/Product.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/product/Product.java
@@ -55,12 +55,15 @@ public class Product extends BaseTimeEntity {
 
     @Column(name = "price", nullable = false, precision = 10, scale = 2, columnDefinition = "DECIMAL(10,2) comment '가격'")
     private BigDecimal price;
-
+    
+    @Column(name = "product_image", columnDefinition = "varchar(255) comment '상품 이미지'")
+    private String productImage;
+    
     @LastModifiedDate
     @Column(name = "deleted_at", columnDefinition = "datetime comment '삭제일'")
     private LocalDateTime deleted_at;
 
-    public static Product create(AddProductRequest request,Category category, Member member){
+    public static Product create(AddProductRequest request,Category category, Member member, String productImage){
         return Product.builder()
             .member(member)
             .category(category)
@@ -68,6 +71,7 @@ public class Product extends BaseTimeEntity {
             .description(request.description())
             .quantity(request.quantity())
             .price(request.price())
+            .productImage(productImage)
             .build();
     }
 }

--- a/src/main/java/com/zb/fresh_api/domain/entity/product/ProductSnapshot.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/product/ProductSnapshot.java
@@ -1,0 +1,76 @@
+package com.zb.fresh_api.domain.entity.product;
+
+import com.zb.fresh_api.domain.entity.category.Category;
+import com.zb.fresh_api.domain.entity.member.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(
+    name = "product_snapshot"
+)
+@EntityListeners(AuditingEntityListener.class)
+public class ProductSnapshot {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", columnDefinition = "BIGINT UNSIGNED comment '고유 번호'")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false, columnDefinition = "BIGINT UNSIGNED comment '상품 고유 번호'")
+    private Product product;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false, columnDefinition = "BIGINT UNSIGNED comment '카테고리 고유 번호'")
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false, columnDefinition = "BIGINT UNSIGNED comment '회원 고유 번호'")
+    private Member member;
+
+    @JoinColumn(name = "name", nullable = false, columnDefinition = "varchar(20)  comment '상품명'")
+    private String name;
+
+    @JoinColumn(name = "description", nullable = false, columnDefinition = "text  comment '상품설명'")
+    private String description;
+
+    @Column(name = "price", nullable = false, precision = 10, scale = 2, columnDefinition = "DECIMAL(10,2) comment '가격'")
+    private BigDecimal price;
+
+    @CreatedDate
+    @Column(name = "snapshot_date", updatable = false, columnDefinition = "datetime comment '스냅샷 생성 일시'")
+    private LocalDateTime snapshotDate;
+
+    public static ProductSnapshot create(Product product) {
+        return  ProductSnapshot.builder()
+            .product(product)
+            .category(product.getCategory())
+            .member(product.getMember())
+            .name(product.getName())
+            .description(product.getDescription())
+            .price(product.getPrice())
+            .build();
+    }
+
+}

--- a/src/main/java/com/zb/fresh_api/domain/repository/jpa/CategoryJpaRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/jpa/CategoryJpaRepository.java
@@ -1,0 +1,9 @@
+package com.zb.fresh_api.domain.repository.jpa;
+
+import com.zb.fresh_api.domain.entity.category.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CategoryJpaRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/zb/fresh_api/domain/repository/jpa/ProductJpaRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/jpa/ProductJpaRepository.java
@@ -1,0 +1,10 @@
+package com.zb.fresh_api.domain.repository.jpa;
+
+import com.zb.fresh_api.domain.entity.product.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductJpaRepository extends JpaRepository<Product, Long> {
+
+}

--- a/src/main/java/com/zb/fresh_api/domain/repository/jpa/ProductSnapshotJpaRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/jpa/ProductSnapshotJpaRepository.java
@@ -1,0 +1,10 @@
+package com.zb.fresh_api.domain.repository.jpa;
+
+import com.zb.fresh_api.domain.entity.product.ProductSnapshot;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductSnapshotJpaRepository extends JpaRepository<ProductSnapshot, Long> {
+
+}

--- a/src/main/java/com/zb/fresh_api/domain/repository/query/CategoryQueryRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/query/CategoryQueryRepository.java
@@ -1,0 +1,24 @@
+package com.zb.fresh_api.domain.repository.query;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zb.fresh_api.domain.entity.category.Category;
+import com.zb.fresh_api.domain.entity.category.QCategory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CategoryQueryRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    QCategory category = QCategory.category;
+
+    public List<Category> findAll() {
+        return jpaQueryFactory
+            .select(category)
+            .from(category)
+            .leftJoin(category.parent).fetchJoin()
+            .fetch();
+    }
+}

--- a/src/main/java/com/zb/fresh_api/domain/repository/query/MemberQueryRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/query/MemberQueryRepository.java
@@ -36,6 +36,17 @@ public class MemberQueryRepository {
             .fetchFirst() != null;
     }
 
+    public boolean existsByPhone(String phone) {
+        QMember member = QMember.member;
+
+        Long count = jpaQueryFactory
+            .select(member.count())
+            .from(member)
+            .where(member.phone.eq(phone))
+            .fetchOne();
+
+        return count != null && count > 0;
+    }
     private BooleanExpression eqEmail(QMember member, String email) {
         return member.email.eq(email);
     }

--- a/src/main/java/com/zb/fresh_api/domain/repository/query/ProductQueryRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/query/ProductQueryRepository.java
@@ -1,0 +1,15 @@
+package com.zb.fresh_api.domain.repository.query;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zb.fresh_api.domain.entity.product.QProduct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    QProduct product = QProduct.product;
+}

--- a/src/main/java/com/zb/fresh_api/domain/repository/reader/CategoryReader.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/reader/CategoryReader.java
@@ -5,6 +5,7 @@ import com.zb.fresh_api.domain.entity.category.Category;
 import com.zb.fresh_api.domain.repository.jpa.CategoryJpaRepository;
 import com.zb.fresh_api.domain.repository.query.CategoryQueryRepository;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @Reader
@@ -16,4 +17,6 @@ public class CategoryReader {
     public List<Category> findAll(){
         return categoryQueryRepository.findAll();
     }
+
+    public Optional<Category> findById(Long id){return categoryJpaRepository.findById(id);}
 }

--- a/src/main/java/com/zb/fresh_api/domain/repository/reader/CategoryReader.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/reader/CategoryReader.java
@@ -1,0 +1,19 @@
+package com.zb.fresh_api.domain.repository.reader;
+
+import com.zb.fresh_api.domain.annotation.Reader;
+import com.zb.fresh_api.domain.entity.category.Category;
+import com.zb.fresh_api.domain.repository.jpa.CategoryJpaRepository;
+import com.zb.fresh_api.domain.repository.query.CategoryQueryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@Reader
+@RequiredArgsConstructor
+public class CategoryReader {
+    private final CategoryJpaRepository categoryJpaRepository;
+    private final CategoryQueryRepository categoryQueryRepository;
+
+    public List<Category> findAll(){
+        return categoryQueryRepository.findAll();
+    }
+}

--- a/src/main/java/com/zb/fresh_api/domain/repository/reader/MemberReader.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/reader/MemberReader.java
@@ -38,4 +38,8 @@ public class MemberReader {
         return memberQueryRepository.existActiveNickname(nickname);
     }
 
+    public boolean existsByPhone(String phone){
+        return memberQueryRepository.existsByPhone(phone);
+    }
+
 }

--- a/src/main/java/com/zb/fresh_api/domain/repository/reader/ProductReader.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/reader/ProductReader.java
@@ -1,0 +1,19 @@
+package com.zb.fresh_api.domain.repository.reader;
+
+import com.zb.fresh_api.domain.annotation.Reader;
+import com.zb.fresh_api.domain.entity.product.Product;
+import com.zb.fresh_api.domain.repository.jpa.ProductJpaRepository;
+import com.zb.fresh_api.domain.repository.query.ProductQueryRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@Reader
+@RequiredArgsConstructor
+public class ProductReader {
+    private final ProductJpaRepository productJpaRepository;
+    private final ProductQueryRepository productQueryRepository;
+
+    public Optional<Product> findById(Long id){
+        return productJpaRepository.findById(id);
+    }
+}

--- a/src/main/java/com/zb/fresh_api/domain/repository/writer/ProductSnapshotWriter.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/writer/ProductSnapshotWriter.java
@@ -1,0 +1,16 @@
+package com.zb.fresh_api.domain.repository.writer;
+
+import com.zb.fresh_api.domain.annotation.Writer;
+import com.zb.fresh_api.domain.entity.product.ProductSnapshot;
+import com.zb.fresh_api.domain.repository.jpa.ProductSnapshotJpaRepository;
+import lombok.RequiredArgsConstructor;
+
+@Writer
+@RequiredArgsConstructor
+public class ProductSnapshotWriter {
+    private final ProductSnapshotJpaRepository productSnapshotJpaRepository;
+
+    public ProductSnapshot store(ProductSnapshot productSnapshot) {
+        return productSnapshotJpaRepository.save(productSnapshot);
+    }
+}

--- a/src/main/java/com/zb/fresh_api/domain/repository/writer/ProductWriter.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/writer/ProductWriter.java
@@ -1,0 +1,20 @@
+package com.zb.fresh_api.domain.repository.writer;
+
+import com.zb.fresh_api.domain.annotation.Writer;
+import com.zb.fresh_api.domain.entity.product.Product;
+import com.zb.fresh_api.domain.repository.jpa.ProductJpaRepository;
+import com.zb.fresh_api.domain.repository.query.ProductQueryRepository;
+import lombok.RequiredArgsConstructor;
+
+@Writer
+@RequiredArgsConstructor
+public class ProductWriter {
+
+    private final ProductJpaRepository productJpaRepository;
+    private final ProductQueryRepository productQueryRepository;
+
+    public Product store(Product product) {
+        return productJpaRepository.save(product);
+    }
+
+}

--- a/src/test/java/com/zb/fresh_api/api/service/CategoryServiceTest.java
+++ b/src/test/java/com/zb/fresh_api/api/service/CategoryServiceTest.java
@@ -1,0 +1,57 @@
+package com.zb.fresh_api.api.service;
+
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+
+import com.zb.fresh_api.api.dto.response.GetAllCategoryResponse;
+import com.zb.fresh_api.common.base.ServiceTest;
+import com.zb.fresh_api.domain.entity.category.Category;
+import com.zb.fresh_api.domain.repository.reader.CategoryReader;
+import java.util.ArrayList;
+import java.util.List;
+import net.jqwik.api.Arbitraries;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+@DisplayName("카테고리 비즈니스 테스트")
+class CategoryServiceTest extends ServiceTest {
+    @Mock
+    private CategoryReader categoryReader;
+
+    @InjectMocks
+    private CategoryService categoryService;
+
+    @Test
+    @DisplayName("카테고리 목록 조회성공")
+    void getAllCategories_success(){
+        // given
+        List<Category> categoryList = new ArrayList<>(List.of(
+            getConstructorMonkey().giveMeBuilder(Category.class)
+                .set("id", Arbitraries.longs().greaterOrEqual(1L))
+                .set("is_used", 1)
+                .set("name", Arbitraries.strings().ofMinLength(1).ofMaxLength(20))
+                .sample(),
+            getConstructorMonkey().giveMeBuilder(Category.class)
+                .set("id", Arbitraries.longs().greaterOrEqual(1L))
+                .set("is_used", 1)
+                .set("name", Arbitraries.strings().ofMinLength(1).ofMaxLength(20))
+                .sample(),
+            getConstructorMonkey().giveMeBuilder(Category.class)
+                .set("id", Arbitraries.longs().greaterOrEqual(1L))
+                .set("is_used", 1)
+                .set("name", Arbitraries.strings().ofMinLength(1).ofMaxLength(20))
+                .sample()
+        ));
+        doReturn(categoryList).when(categoryReader).findAll();
+
+        // when
+        GetAllCategoryResponse response = categoryService.getAllCategories();
+
+        // then
+        assertNotNull(response);
+        assertEquals(categoryList.size(), response.categories().size());
+    }
+}

--- a/src/test/java/com/zb/fresh_api/api/service/ProductServiceTest.java
+++ b/src/test/java/com/zb/fresh_api/api/service/ProductServiceTest.java
@@ -1,0 +1,151 @@
+package com.zb.fresh_api.api.service;
+
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+import com.zb.fresh_api.api.dto.request.AddProductRequest;
+import com.zb.fresh_api.api.dto.response.AddProductResponse;
+import com.zb.fresh_api.common.base.ServiceTest;
+import com.zb.fresh_api.common.exception.CustomException;
+import com.zb.fresh_api.common.exception.ResponseCode;
+import com.zb.fresh_api.domain.entity.category.Category;
+import com.zb.fresh_api.domain.entity.member.Member;
+import com.zb.fresh_api.domain.entity.product.Product;
+import com.zb.fresh_api.domain.enums.member.Provider;
+import com.zb.fresh_api.domain.repository.reader.CategoryReader;
+import com.zb.fresh_api.domain.repository.writer.ProductWriter;
+import java.math.BigDecimal;
+import java.util.Optional;
+import net.jqwik.api.Arbitraries;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+@DisplayName("제품 관련 비즈니스 테스트")
+class ProductServiceTest extends ServiceTest {
+
+    @Mock
+    private ProductWriter productWriter;
+
+    @Mock
+    private CategoryReader categoryReader;
+
+    @InjectMocks
+    private ProductService productService;
+
+    @DisplayName("제품 등록 성공")
+    @RepeatedTest(value = 10, name = RepeatedTest.LONG_DISPLAY_NAME)
+
+    void addProduct_success() {
+        // given
+        Long categoryId = Arbitraries.longs().greaterOrEqual(1L).sample();
+        AddProductRequest addProductRequest = getConstructorMonkey().giveMeBuilder(
+                AddProductRequest.class)
+            .set("name", Arbitraries.strings().ofMinLength(1))
+            .set("quantity", Arbitraries.integers().greaterOrEqual(1))
+            .set("description", Arbitraries.strings().ofMinLength(1).ofMaxLength(250))
+            .set("price", Arbitraries.bigDecimals().greaterOrEqual(BigDecimal.valueOf(1)))
+            .set("categoryId", categoryId)
+            .sample();
+        Member member = getConstructorMonkey().giveMeBuilder(Member.class)
+            .set("id", Arbitraries.longs().greaterOrEqual(4L))
+            .set("provider", Arbitraries.of(Provider.class))
+            .set("providerId",
+                Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(50))
+            .set("isSeller", true)
+            .set("email" , Arbitraries.strings().withCharRange('a','z') + "@test.com")
+            .sample();
+        Category category = getConstructorMonkey().giveMeBuilder(Category.class)
+            .set("id", addProductRequest.categoryId())
+            .set("name", Arbitraries.strings().ofMinLength(1))
+            .sample();
+        Product product = getConstructorMonkey().giveMeBuilder(Product.class)
+            .set("member", member)
+            .set("category", category)
+            .set("name" , addProductRequest.name())
+            .sample();
+
+        doReturn(Optional.of(category)).when(categoryReader)
+            .findById(addProductRequest.categoryId());
+        doReturn(product).when(productWriter).store(argThat(x ->
+                x.getName().equals(addProductRequest.name()) &&
+                    x.getMember().getEmail().equals(member.getEmail()) &&
+                    x.getCategory().getName().equals(category.getName())
+            )
+
+        );
+        // When
+        AddProductResponse response = productService.addProduct(addProductRequest,
+            member);
+
+        // then
+        assertNotNull(response);
+        assertEquals(addProductRequest.name(), response.name());
+        verify(categoryReader).findById(categoryId);
+        verify(productWriter).store(any(Product.class));
+    }
+
+    @DisplayName("제품 등록 실패 - 사용자가 판매자가 아님")
+    @RepeatedTest(value = 10, name = RepeatedTest.LONG_DISPLAY_NAME)
+
+    void addProduct_fail_UNAUTHORIZED() {
+        // given
+        AddProductRequest addProductRequest = getConstructorMonkey().giveMeBuilder(
+                AddProductRequest.class)
+            .set("name", Arbitraries.strings().ofMinLength(1))
+            .set("quantity", Arbitraries.integers().greaterOrEqual(1))
+            .set("description", Arbitraries.strings().ofMinLength(1).ofMaxLength(250))
+            .set("price", Arbitraries.bigDecimals().greaterOrEqual(BigDecimal.valueOf(1)))
+            .set("categoryId", Arbitraries.longs().greaterOrEqual(1L))
+            .sample();
+        Member member = getConstructorMonkey().giveMeBuilder(Member.class)
+            .set("id", Arbitraries.longs().greaterOrEqual(4L))
+            .set("provider", Arbitraries.of(Provider.class))
+            .set("providerId",
+                Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(50))
+            .set("isSeller", false)
+            .sample();
+
+        // When
+        CustomException exception = assertThrows(CustomException.class, () -> productService.addProduct(addProductRequest, member));
+
+        // then
+        assertEquals(ResponseCode.UNAUTHORIZED_ACCESS_EXCEPTION, exception.getResponseCode());
+    }
+
+    @DisplayName("제품 등록 실패 - 카테고리 ID가 유효하지 않음")
+//    @Test
+    @RepeatedTest(value = 10, name = RepeatedTest.LONG_DISPLAY_NAME)
+    void addProduct_fail_INVALID_CATEGORYID() {
+        // given
+        AddProductRequest addProductRequest = getConstructorMonkey().giveMeBuilder(
+                AddProductRequest.class)
+            .set("name", Arbitraries.strings().ofMinLength(1))
+            .set("quantity", Arbitraries.integers().greaterOrEqual(1))
+            .set("description", Arbitraries.strings().ofMinLength(1).ofMaxLength(250))
+            .set("price", Arbitraries.bigDecimals().greaterOrEqual(BigDecimal.valueOf(1)))
+            .set("categoryId", Arbitraries.longs().greaterOrEqual(1L))
+            .sample();
+        Member member = getConstructorMonkey().giveMeBuilder(Member.class)
+            .set("id", Arbitraries.longs().greaterOrEqual(4L))
+            .set("provider", Arbitraries.of(Provider.class))
+            .set("providerId",
+                Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(50))
+            .set("isSeller", true)
+            .sample();
+
+        doReturn(Optional.empty()).when(categoryReader).findById(addProductRequest.categoryId());
+
+        // When
+        CustomException exception = assertThrows(CustomException.class, () -> productService.addProduct(addProductRequest, member));
+
+        // then
+        assertEquals(ResponseCode.CATEGORY_NOT_VALID, exception.getResponseCode());
+    }
+}

--- a/src/test/java/com/zb/fresh_api/api/service/ProductServiceTest.java
+++ b/src/test/java/com/zb/fresh_api/api/service/ProductServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.zb.fresh_api.api.dto.request.AddProductRequest;
@@ -23,9 +24,10 @@ import java.math.BigDecimal;
 import java.util.Optional;
 import net.jqwik.api.Arbitraries;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.web.multipart.MultipartFile;
 
 @DisplayName("제품 관련 비즈니스 테스트")
 class ProductServiceTest extends ServiceTest {
@@ -40,8 +42,7 @@ class ProductServiceTest extends ServiceTest {
     private ProductService productService;
 
     @DisplayName("제품 등록 성공")
-    @RepeatedTest(value = 10, name = RepeatedTest.LONG_DISPLAY_NAME)
-
+    @Test
     void addProduct_success() {
         // given
         Long categoryId = Arbitraries.longs().greaterOrEqual(1L).sample();
@@ -70,6 +71,7 @@ class ProductServiceTest extends ServiceTest {
             .set("category", category)
             .set("name" , addProductRequest.name())
             .sample();
+        MultipartFile multipartFile = mock(MultipartFile.class);
 
         doReturn(Optional.of(category)).when(categoryReader)
             .findById(addProductRequest.categoryId());
@@ -82,7 +84,7 @@ class ProductServiceTest extends ServiceTest {
         );
         // When
         AddProductResponse response = productService.addProduct(addProductRequest,
-            member);
+            member, multipartFile);
 
         // then
         assertNotNull(response);
@@ -92,8 +94,7 @@ class ProductServiceTest extends ServiceTest {
     }
 
     @DisplayName("제품 등록 실패 - 사용자가 판매자가 아님")
-    @RepeatedTest(value = 10, name = RepeatedTest.LONG_DISPLAY_NAME)
-
+    @Test
     void addProduct_fail_UNAUTHORIZED() {
         // given
         AddProductRequest addProductRequest = getConstructorMonkey().giveMeBuilder(
@@ -112,16 +113,18 @@ class ProductServiceTest extends ServiceTest {
             .set("isSeller", false)
             .sample();
 
+        MultipartFile multipartFile = mock(MultipartFile.class);
+
         // When
-        CustomException exception = assertThrows(CustomException.class, () -> productService.addProduct(addProductRequest, member));
+        CustomException exception = assertThrows(CustomException.class, () -> productService.addProduct(addProductRequest, member,
+            multipartFile));
 
         // then
         assertEquals(ResponseCode.UNAUTHORIZED_ACCESS_EXCEPTION, exception.getResponseCode());
     }
 
     @DisplayName("제품 등록 실패 - 카테고리 ID가 유효하지 않음")
-//    @Test
-    @RepeatedTest(value = 10, name = RepeatedTest.LONG_DISPLAY_NAME)
+    @Test
     void addProduct_fail_INVALID_CATEGORYID() {
         // given
         AddProductRequest addProductRequest = getConstructorMonkey().giveMeBuilder(
@@ -139,11 +142,13 @@ class ProductServiceTest extends ServiceTest {
                 Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(50))
             .set("isSeller", true)
             .sample();
+        MultipartFile multipartFile = mock(MultipartFile.class);
 
         doReturn(Optional.empty()).when(categoryReader).findById(addProductRequest.categoryId());
 
         // When
-        CustomException exception = assertThrows(CustomException.class, () -> productService.addProduct(addProductRequest, member));
+        CustomException exception = assertThrows(CustomException.class, () -> productService.addProduct(addProductRequest, member,
+            multipartFile));
 
         // then
         assertEquals(ResponseCode.CATEGORY_NOT_VALID, exception.getResponseCode());

--- a/src/test/java/com/zb/fresh_api/api/service/ProductServiceTest.java
+++ b/src/test/java/com/zb/fresh_api/api/service/ProductServiceTest.java
@@ -157,7 +157,7 @@ class ProductServiceTest extends ServiceTest {
             multipartFile));
 
         // then
-        assertEquals(ResponseCode.CATEGORY_NOT_VALID, exception.getResponseCode());
+        assertEquals(ResponseCode.CATEGORY_NOT_FOUND, exception.getResponseCode());
     }
 
     @Test


### PR DESCRIPTION
## 작업

1. 엔티티 추가
  * Product, ProductSnapShot
2. 기능 추가
  * 카테고리 목록 조회
    * 단순하게 카테고리 DB에서 모든 카테고리를 가져오는 역할입니다.
    * 초기 서버에서 카테고리 목록을 가지고 있어야합니다
    
  * 상품 등록
    * 상품 request , multipart 두가지 타입을 동시에 입력받습니다.  스웨거에서는 하나의 요청에 각각 다른 타입을 지정해줄 수 없기때문에 이를 위해 octet-stream타입을 받으면 objectMapper로 파싱해주는 컨버터를 추가했습니다.  
    * 등록 로직은 1. 사용자가 판매자인증을 받았는지 2. 요청으로 들어온 카테고리가 유효한지 3. 사진을 받았다면 S3에 저장 후 url생성한 뒤 저장합니다.
    
  * 상품 상세 조회
  * 상품 수정
    * 삭제와 마찬가지로 request, multipart 두가지 타입을 동시에 입력받습니다. ProductId가 유효한지, 등록한 사용자와 수정 요청 사용자가 일치하는지,  확인후 상품과 상품 스냅샷을 저장합니다.
   
  * 상품 삭제
 
3. 판매자 인증 로직 수정
* 기존에는 인증만 있었는데 비즈니스 로직을 추가하였습니다.
* 인증 요청 시 jwt가 필요합니다.
* 인증 코드 인증 시 인증이 성공하면 jwt의 멤버가 판매자 인증이 됩니다

## 참고 사항

이후 작업 예정 사항
* 좋아요, 좋아요 취소
* 커뮤니티 게시글 CRUD

## 관련 이슈
- #3
