### PR TITLE
FEAT : 소셜 로그인 리팩토링, 시큐리티, 스웨거 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ out/
 .vscode/
 
 ### yml ###
-*.yml
+*-local.yml
 
 ### mac ###
 .DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.zb'
-version = '0.0.1-SNAPSHOT'
+version = ''
 
 java {
 	toolchain {
@@ -44,6 +44,9 @@ dependencies {
 
 	// feign
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.3'
+
+	// aws cloud parameter-store
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store:3.1.1'
 
 	// lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/zb/fresh_api/api/client/KakaoAuthClient.java
+++ b/src/main/java/com/zb/fresh_api/api/client/KakaoAuthClient.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface KakaoAuthClient {
 
     @PostMapping(value = "/oauth/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-    KakaoToken generateOAuthToken(@RequestParam(name = "grant_type") String grantType,
+    KakaoToken generateOauthToken(@RequestParam(name = "grant_type") String grantType,
                                   @RequestParam(name = "client_id") String clientId,
                                   @RequestParam(name = "redirect_uri") String redirectUri,
                                   @RequestParam(name = "code") String code,

--- a/src/main/java/com/zb/fresh_api/api/config/SecurityConfig.java
+++ b/src/main/java/com/zb/fresh_api/api/config/SecurityConfig.java
@@ -1,8 +1,11 @@
 package com.zb.fresh_api.api.config;
 
+import com.zb.fresh_api.api.exception.CustomAuthenticationEntryPoint;
 import com.zb.fresh_api.api.filter.JwtAuthenticationFilter;
 import com.zb.fresh_api.api.filter.JwtExceptionFilter;
+import com.zb.fresh_api.api.principal.CustomUserDetailsService;
 import com.zb.fresh_api.common.constants.SecurityConstants;
+import com.zb.fresh_api.api.exception.CustomAccessDeniedHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -34,6 +37,9 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtExceptionFilter jwtExceptionFilter;
 
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -45,7 +51,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, CustomUserDetailsService customUserDetailsService) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)
@@ -59,6 +65,12 @@ public class SecurityConfig {
                                 .requestMatchers(OPTIONS, "**").permitAll()
                                 .requestMatchers(SecurityConstants.SWAGGER_PATH).permitAll()
                                 .requestMatchers(SecurityConstants.PERMIT_ALL_PATH).permitAll()
+                )
+
+                .exceptionHandling(e ->
+                        e
+                                .authenticationEntryPoint(authenticationEntryPoint)
+                                .accessDeniedHandler(accessDeniedHandler)
                 )
 
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/zb/fresh_api/api/config/SecurityConfig.java
+++ b/src/main/java/com/zb/fresh_api/api/config/SecurityConfig.java
@@ -1,11 +1,10 @@
 package com.zb.fresh_api.api.config;
 
+import com.zb.fresh_api.api.exception.CustomAccessDeniedHandler;
 import com.zb.fresh_api.api.exception.CustomAuthenticationEntryPoint;
 import com.zb.fresh_api.api.filter.JwtAuthenticationFilter;
 import com.zb.fresh_api.api.filter.JwtExceptionFilter;
-import com.zb.fresh_api.api.principal.CustomUserDetailsService;
 import com.zb.fresh_api.common.constants.SecurityConstants;
-import com.zb.fresh_api.api.exception.CustomAccessDeniedHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -51,7 +50,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, CustomUserDetailsService customUserDetailsService) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)
@@ -65,6 +64,7 @@ public class SecurityConfig {
                                 .requestMatchers(OPTIONS, "**").permitAll()
                                 .requestMatchers(SecurityConstants.SWAGGER_PATH).permitAll()
                                 .requestMatchers(SecurityConstants.PERMIT_ALL_PATH).permitAll()
+                                .anyRequest().authenticated()
                 )
 
                 .exceptionHandling(e ->

--- a/src/main/java/com/zb/fresh_api/api/config/SwaggerConfig.java
+++ b/src/main/java/com/zb/fresh_api/api/config/SwaggerConfig.java
@@ -12,7 +12,8 @@ import org.springframework.context.annotation.Profile;
 @Profile("!prod")
 @OpenAPIDefinition(
         servers = {
-                @Server(url = "http://localhost:8080", description = "Local")
+                @Server(url = "http://localhost:8080", description = "Local"),
+                @Server(url = "https://api.jihun-dev.kr", description = "Dev")
         }
 )
 @io.swagger.v3.oas.annotations.security.SecurityScheme(

--- a/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
@@ -36,8 +36,8 @@ public class MemberController {
             summary = "회원 가입",
             description = "이메일회원가입, Oauth2회원가입에 사용되는 API입니다"
     )
-    @PostMapping("/auth/signup")
-    public ResponseEntity<ApiResponse<Void>> signUp(@RequestBody @Valid SignUpRequest request) {
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<Void>> signup(@RequestBody @Valid SignUpRequest request) {
         memberService.signUp(request.email(), request.password(), request.nickname(), request.termsAgreements(), request.provider(), request.providerId());
         return ApiResponse.success(ResponseCode.SUCCESS);
     }
@@ -46,7 +46,7 @@ public class MemberController {
             summary = "로그인",
             description = "이메일 가입 회원의 로그인을 진행한다."
     )
-    @PostMapping("/auth/login")
+    @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> loginWithEmail(@Valid @RequestBody LoginRequest request) {
         return ApiResponse.success(ResponseCode.SUCCESS, memberService.login(request));
     }
@@ -55,7 +55,7 @@ public class MemberController {
             summary = "카카오 로그인",
             description = "카카오 로그인을 진행한다."
     )
-    @PostMapping("/auth/kakao")
+    @PostMapping("/login/kakao")
     public ResponseEntity<ApiResponse<OauthLoginResponse>> loginWithKakao(@Valid @RequestBody OauthLoginRequest request) {
         return ApiResponse.success(ResponseCode.SUCCESS, memberService.oauthLogin(request));
     }

--- a/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
@@ -36,7 +36,7 @@ public class MemberController {
             summary = "회원 가입",
             description = "이메일회원가입, Oauth2회원가입에 사용되는 API입니다"
     )
-    @PostMapping("/signup")
+    @PostMapping("/auth/signup")
     public ResponseEntity<ApiResponse<Void>> signUp(@RequestBody @Valid SignUpRequest request) {
         memberService.signUp(request.email(), request.password(), request.nickname(), request.termsAgreements(), request.provider(), request.providerId());
         return ApiResponse.success(ResponseCode.SUCCESS);
@@ -46,8 +46,8 @@ public class MemberController {
             summary = "로그인",
             description = "이메일 가입 회원의 로그인을 진행한다."
     )
-    @PostMapping("/login")
-    public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
+    @PostMapping("/auth/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> loginWithEmail(@Valid @RequestBody LoginRequest request) {
         return ApiResponse.success(ResponseCode.SUCCESS, memberService.login(request));
     }
 
@@ -55,8 +55,8 @@ public class MemberController {
             summary = "카카오 로그인",
             description = "카카오 로그인을 진행한다."
     )
-    @PostMapping("/login/kakao")
-    public ResponseEntity<ApiResponse<OauthLoginResponse>> login(@Valid @RequestBody OauthLoginRequest request) {
+    @PostMapping("/auth/kakao")
+    public ResponseEntity<ApiResponse<OauthLoginResponse>> loginWithKakao(@Valid @RequestBody OauthLoginRequest request) {
         return ApiResponse.success(ResponseCode.SUCCESS, memberService.oauthLogin(request));
     }
 

--- a/src/main/java/com/zb/fresh_api/api/controller/health/HealthCheckController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/health/HealthCheckController.java
@@ -1,0 +1,30 @@
+package com.zb.fresh_api.api.controller.health;
+
+import com.zb.fresh_api.common.exception.ResponseCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+        name = "헬스체크 API",
+        description = "헬스체크"
+)
+@RestController
+@RequestMapping("/health")
+@RequiredArgsConstructor
+public class HealthCheckController {
+
+    @Operation(
+            summary = "헬스 체크",
+            description = "서버 헬스 체크를 진행합니다."
+    )
+    @GetMapping
+    public ResponseEntity<String> check() {
+        return ResponseEntity.ok().body(ResponseCode.SUCCESS.getMessage());
+    }
+
+}

--- a/src/main/java/com/zb/fresh_api/api/dto/response/LoginResponse.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/response/LoginResponse.java
@@ -1,6 +1,6 @@
 package com.zb.fresh_api.api.dto.response;
 
-import com.zb.fresh_api.api.dto.LoginMember;
+import com.zb.fresh_api.domain.dto.member.LoginMember;
 import com.zb.fresh_api.domain.dto.token.Token;
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/zb/fresh_api/api/dto/response/OauthLoginResponse.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/response/OauthLoginResponse.java
@@ -1,6 +1,7 @@
 package com.zb.fresh_api.api.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.zb.fresh_api.domain.dto.member.OauthLoginMember;
 import com.zb.fresh_api.domain.dto.token.Token;
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/zb/fresh_api/api/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/zb/fresh_api/api/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,31 @@
+package com.zb.fresh_api.api.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zb.fresh_api.common.exception.ResponseCode;
+import com.zb.fresh_api.common.response.ApiResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String errorResponse = objectMapper.writeValueAsString(ApiResponse.error(ResponseCode.FORBIDDEN, accessDeniedException));
+        response.getWriter().write(errorResponse);
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/zb/fresh_api/api/exception/CustomAccessDeniedHandler.java
@@ -25,7 +25,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
 
         ObjectMapper objectMapper = new ObjectMapper();
-        String errorResponse = objectMapper.writeValueAsString(ApiResponse.error(ResponseCode.FORBIDDEN, accessDeniedException));
+        String errorResponse = objectMapper.writeValueAsString(ApiResponse.error(ResponseCode.FORBIDDEN, accessDeniedException).getBody());
         response.getWriter().write(errorResponse);
     }
 }

--- a/src/main/java/com/zb/fresh_api/api/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/zb/fresh_api/api/exception/CustomAuthenticationEntryPoint.java
@@ -25,7 +25,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
 
         ObjectMapper objectMapper = new ObjectMapper();
-        String errorResponse = objectMapper.writeValueAsString(ApiResponse.error(ResponseCode.UNAUTHORIZED, authException));
+        String errorResponse = objectMapper.writeValueAsString(ApiResponse.error(ResponseCode.UNAUTHORIZED, authException).getBody());
         response.getWriter().write(errorResponse);
 
     }

--- a/src/main/java/com/zb/fresh_api/api/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/zb/fresh_api/api/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,32 @@
+package com.zb.fresh_api.api.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zb.fresh_api.common.exception.ResponseCode;
+import com.zb.fresh_api.common.response.ApiResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String errorResponse = objectMapper.writeValueAsString(ApiResponse.error(ResponseCode.UNAUTHORIZED, authException));
+        response.getWriter().write(errorResponse);
+
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/factory/OauthProviderFactory.java
+++ b/src/main/java/com/zb/fresh_api/api/factory/OauthProviderFactory.java
@@ -41,14 +41,14 @@ public class OauthProviderFactory {
     }
 
     public String getAccessToken(Provider provider, String redirectUri, String code) {
-        return getOAuthToken(provider, redirectUri, code).accessToken();
+        return getOauthToken(provider, redirectUri, code).accessToken();
     }
 
-    private OauthToken getOAuthToken(Provider provider, String redirectUri, String code) {
+    private OauthToken getOauthToken(Provider provider, String redirectUri, String code) {
         return getOauthProvider(provider).getOauthToken(redirectUri, code);
     }
 
-    public OauthUser getOAuthUser(Provider provider, String accessToken) {
+    public OauthUser getOauthUser(Provider provider, String accessToken) {
         return getOauthProvider(provider).getOauthUser(accessToken);
     }
 

--- a/src/main/java/com/zb/fresh_api/api/provider/oauth/KakaoProvider.java
+++ b/src/main/java/com/zb/fresh_api/api/provider/oauth/KakaoProvider.java
@@ -27,7 +27,7 @@ public class KakaoProvider implements OauthProvider {
 
     @Override
     public OauthToken getOauthToken(String redirectUri, String code) {
-        return kakaoAuthClient.generateOAuthToken(
+        return kakaoAuthClient.generateOauthToken(
                 grantType,
                 clientId,
                 redirectUri,

--- a/src/main/java/com/zb/fresh_api/api/service/MemberService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/MemberService.java
@@ -33,6 +33,7 @@ import com.zb.fresh_api.domain.repository.writer.MemberWriter;
 import com.zb.fresh_api.domain.repository.writer.PointHistoryWriter;
 import com.zb.fresh_api.domain.repository.writer.PointWriter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,6 +45,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/src/main/java/com/zb/fresh_api/api/service/MemberService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/MemberService.java
@@ -1,12 +1,10 @@
 package com.zb.fresh_api.api.service;
 
-import com.zb.fresh_api.api.dto.LoginMember;
 import com.zb.fresh_api.api.dto.TermsAgreementDto;
 import com.zb.fresh_api.api.dto.request.LoginRequest;
 import com.zb.fresh_api.api.dto.request.OauthLoginRequest;
 import com.zb.fresh_api.api.dto.request.UpdateProfileRequest;
 import com.zb.fresh_api.api.dto.response.LoginResponse;
-import com.zb.fresh_api.api.dto.response.OauthLoginMember;
 import com.zb.fresh_api.api.dto.response.OauthLoginResponse;
 import com.zb.fresh_api.api.factory.OauthProviderFactory;
 import com.zb.fresh_api.api.principal.CustomUserDetails;
@@ -14,6 +12,8 @@ import com.zb.fresh_api.api.principal.CustomUserDetailsService;
 import com.zb.fresh_api.api.provider.TokenProvider;
 import com.zb.fresh_api.common.exception.CustomException;
 import com.zb.fresh_api.common.exception.ResponseCode;
+import com.zb.fresh_api.domain.dto.member.LoginMember;
+import com.zb.fresh_api.domain.dto.member.OauthLoginMember;
 import com.zb.fresh_api.domain.dto.member.OauthUser;
 import com.zb.fresh_api.domain.dto.token.Token;
 import com.zb.fresh_api.domain.entity.member.Member;
@@ -32,17 +32,13 @@ import com.zb.fresh_api.domain.repository.writer.MemberTermsWriter;
 import com.zb.fresh_api.domain.repository.writer.MemberWriter;
 import com.zb.fresh_api.domain.repository.writer.PointHistoryWriter;
 import com.zb.fresh_api.domain.repository.writer.PointWriter;
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
@@ -83,7 +79,7 @@ public class MemberService {
     public OauthLoginResponse oauthLogin(final OauthLoginRequest request) {
         final Provider provider = request.provider();
         final String accessToken = oauthProviderFactory.getAccessToken(provider, request.redirectUri(), request.code());
-        final OauthUser oAuthUser = oauthProviderFactory.getOAuthUser(provider, accessToken);
+        final OauthUser oAuthUser = oauthProviderFactory.getOauthUser(provider, accessToken);
 
         final String email = oAuthUser.email();
         final boolean isSignup = memberReader.existsByEmailAndProvider(email, provider);

--- a/src/main/java/com/zb/fresh_api/api/utils/SmsUtil.java
+++ b/src/main/java/com/zb/fresh_api/api/utils/SmsUtil.java
@@ -1,6 +1,5 @@
 package com.zb.fresh_api.api.utils;
 
-
 import com.zb.fresh_api.common.exception.CustomException;
 import com.zb.fresh_api.common.exception.ResponseCode;
 import jakarta.annotation.PostConstruct;

--- a/src/main/java/com/zb/fresh_api/common/constants/SecurityConstants.java
+++ b/src/main/java/com/zb/fresh_api/common/constants/SecurityConstants.java
@@ -10,6 +10,7 @@ public class SecurityConstants {
     public static final String[] ALLOW_ORIGINS = {
             "http://localhost:8080",
             "https://api.jihun-dev.kr",
+            "https://jihun-dev.kr",
     };
 
     public static final String[] SWAGGER_PATH = {
@@ -23,9 +24,16 @@ public class SecurityConstants {
 
     public static final String[] PERMIT_ALL_PATH = {
             /**
+             * Health
+            */
+            "/health",
+
+            /**
              * Member
             */
-            "/v1/api/members/auth/**",
+            "/v1/api/members/signup",
+            "/v1/api/members/login",
+            "/v1/api/members/login/**",
             "/v1/api/members/check-nickname",
             "/v1/api/members/check-email",
 

--- a/src/main/java/com/zb/fresh_api/common/constants/SecurityConstants.java
+++ b/src/main/java/com/zb/fresh_api/common/constants/SecurityConstants.java
@@ -9,10 +9,12 @@ public class SecurityConstants {
 
     public static final String[] ALLOW_ORIGINS = {
             "http://localhost:8080",
+            "https://api.jihun-dev.kr",
     };
 
     public static final String[] SWAGGER_PATH = {
-            "/swagger-ui/**", "/api-docs/**",
+            "/swagger-ui/**",
+            "/api-docs/**",
     };
 
     public static final String[] WEB_IGNORE_PATH = {
@@ -20,7 +22,17 @@ public class SecurityConstants {
     };
 
     public static final String[] PERMIT_ALL_PATH = {
-            "/v1/api/members/signup", "/v1/api/members/login/**"
+            /**
+             * Member
+            */
+            "/v1/api/members/auth/**",
+            "/v1/api/members/check-nickname",
+            "/v1/api/members/check-email",
+
+            /**
+             * Terms
+            */
+            "/v1/api/terms/**"
     };
 
 }

--- a/src/main/java/com/zb/fresh_api/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zb/fresh_api/common/exception/GlobalExceptionHandler.java
@@ -17,4 +17,10 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return ApiResponse.fail(e.getResponseCode());
     }
 
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ApiResponse<String>> handle(RuntimeException e) {
+        log.error("RuntimeException : {}", e.getMessage());
+        return ApiResponse.fail(ResponseCode.COMMON_INVALID_PARAM, e.getMessage());
+    }
+
 }

--- a/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
+++ b/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
@@ -15,11 +15,13 @@ public enum ResponseCode {
     /**
      * Common (0600 ~ 0800)
      */
-    NOT_FOUND_ENUM_CONSTANT("0600", "열거형 상수값을 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR("0600", "내부 서버 오류가 발생하였습니다."),
     IS_NULL("0601", "NULL 값이 들어왔습니다."),
     COMMON_INVALID_PARAM("0602", "요청한 값이 올바르지 않습니다."),
     INVALID_AUTHENTICATION("0603", "인증이 올바르지 않습니다."),
     NO_SUCH_METHOD("0604", "메소드를 찾을 수 없습니다."),
+    NOT_FOUND_ENUM_CONSTANT("0605", "열거형 상수값을 찾을 수 없습니다."),
+    S3_UPLOADER_ERROR("0606", "S3 업로드 중 오류가 발생하였습니다."),
 
     FORBIDDEN("0700", "접근 권한이 없습니다."),
     UNAUTHORIZED("0701", "유효한 인증 자격이 없습니다."),

--- a/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
+++ b/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
@@ -13,13 +13,16 @@ public enum ResponseCode {
     SUCCESS("0200", "성공했습니다."),
 
     /**
-     * Common (0600 ~ 0700)
+     * Common (0600 ~ 0800)
      */
     NOT_FOUND_ENUM_CONSTANT("0600", "열거형 상수값을 찾을 수 없습니다."),
     IS_NULL("0601", "NULL 값이 들어왔습니다."),
     COMMON_INVALID_PARAM("0602", "요청한 값이 올바르지 않습니다."),
     INVALID_AUTHENTICATION("0603", "인증이 올바르지 않습니다."),
     NO_SUCH_METHOD("0604", "메소드를 찾을 수 없습니다."),
+
+    FORBIDDEN("0700", "접근 권한이 없습니다."),
+    UNAUTHORIZED("0701", "유효한 인증 자격이 없습니다."),
 
     /**
      * Member (1000 ~ 1100)

--- a/src/main/java/com/zb/fresh_api/common/response/ApiResponse.java
+++ b/src/main/java/com/zb/fresh_api/common/response/ApiResponse.java
@@ -34,7 +34,7 @@ public record ApiResponse<T>(
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse<>(false, responseCode.getCode(), responseCode.getMessage(), data));
     }
 
-    public static <T> ResponseEntity<ApiResponse<String>> error(ResponseCode responseCode, RuntimeException exception) {
+    public static ResponseEntity<ApiResponse<String>> error(ResponseCode responseCode, RuntimeException exception) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse<>(false, responseCode.getCode(), responseCode.getMessage(), exception.getMessage()));
     }
 

--- a/src/main/java/com/zb/fresh_api/domain/dto/member/LoginMember.java
+++ b/src/main/java/com/zb/fresh_api/domain/dto/member/LoginMember.java
@@ -1,4 +1,4 @@
-package com.zb.fresh_api.api.dto;
+package com.zb.fresh_api.domain.dto.member;
 
 import com.zb.fresh_api.domain.entity.member.Member;
 import com.zb.fresh_api.domain.enums.member.Provider;

--- a/src/main/java/com/zb/fresh_api/domain/dto/member/OauthLoginMember.java
+++ b/src/main/java/com/zb/fresh_api/domain/dto/member/OauthLoginMember.java
@@ -1,4 +1,4 @@
-package com.zb.fresh_api.api.dto.response;
+package com.zb.fresh_api.domain.dto.member;
 
 import com.zb.fresh_api.domain.enums.member.Provider;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,81 @@
+server:
+  port: 8080
+
+spring:
+  config:
+    activate:
+      on-profile: dev
+#    import: aws-parameterstore:/param/fresh2you_dev/
+
+  security:
+    oauth2:
+      client:
+        provider:
+          kakao:
+            authorizationUri: https://kauth.kakao.com/oauth/authorize
+            tokenUri: https://kauth.kakao.com/oauth/token
+            userInfoUri: https://kapi.kakao.com/v2/user/me
+            userNameAttribute: id
+
+        registration:
+          kakao:
+            clientId: ${kakao.client.id}
+            clientSecret: ${kakao.client.secret}
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            client-name: kakao
+            redirectUri: ${kakao.client.redirect.uri}
+            scope:
+              #            - profile_nickname
+              #            - profile_image
+              - account_email
+
+  mail:
+    host: smtp.gmail.com
+    port: ${mail.port}
+    username: ${mail.username}
+    password: ${mail.password}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          timeout: 5000
+          starttls:
+            enable: true
+
+  coolsms:
+    apiKey: ${coolsms.key}
+    apiSecret: ${coolsms.secret}
+    fromNumber: ${coolsms.number}
+    apiUrl: https://api.coolsms.co.kr
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  jwt:
+    secret: ${jwt.secret}
+
+  datasource:
+    driver-class-name: ${datasource.driver}
+    url: ${datasource.url}
+    username: ${datasource.username}
+    password: ${datasource.password}
+
+  jpa:
+    open-in-view: true
+    hibernate:
+      ddl-auto: update
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        format_sql: true      # 쿼리 로그 포맷 (정렬)
+        show_sql: false        # 쿼리 로그 출력
+
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
-  profiles:
-    active: local
+  config:
+    import: aws-parameterstore:/param/fresh2you_${spring.profiles.active}/
 
 springdoc:
   api-docs:

--- a/src/test/java/com/zb/fresh_api/api/controller/MemberControllerTest.java
+++ b/src/test/java/com/zb/fresh_api/api/controller/MemberControllerTest.java
@@ -105,7 +105,7 @@ class MemberControllerTest {
 
     @Test
     @DisplayName("회원가입 성공")
-    void signUp_success() throws Exception {
+    void signup_success() throws Exception {
         TermsAgreementDto termsAgreementDto = new TermsAgreementDto(1L, true);
         SignUpRequest request = new SignUpRequest("test@example.com", "password",
             "password", "nickname", List.of(termsAgreementDto), Provider.EMAIL,

--- a/src/test/java/com/zb/fresh_api/api/service/MemberServiceTest.java
+++ b/src/test/java/com/zb/fresh_api/api/service/MemberServiceTest.java
@@ -106,7 +106,7 @@ class MemberServiceTest extends ServiceTest {
         Token token = Token.emptyToken();
 
         doReturn(accessToken).when(oauthProviderFactory).getAccessToken(request.provider(), request.redirectUri(), request.code());
-        doReturn(oauthUser).when(oauthProviderFactory).getOAuthUser(request.provider(), accessToken);
+        doReturn(oauthUser).when(oauthProviderFactory).getOauthUser(request.provider(), accessToken);
         doReturn(isSignup).when(memberReader).existsByEmailAndProvider(oauthUser.email(), request.provider());
 
         // when
@@ -120,7 +120,7 @@ class MemberServiceTest extends ServiceTest {
         Assertions.assertEquals(response.token(), token);
 
         verify(oauthProviderFactory).getAccessToken(request.provider(), request.redirectUri(), request.code());
-        verify(oauthProviderFactory).getOAuthUser(request.provider(), accessToken);
+        verify(oauthProviderFactory).getOauthUser(request.provider(), accessToken);
         verify(memberReader).existsByEmailAndProvider(oauthUser.email(), request.provider());
 
     }


### PR DESCRIPTION
## 작업
### 소셜 로그인 리팩토링 
소셜 로그인 Mapping Url 정보 및 메소드명의 누락된 카멜 케이스를 추가했습니다.

### 시큐리티 설정 추가
CORS 오리진에 개발 서버 URL을 추가했습니다.
토큰이 필요하지 않은 URL에 대해 Security 설정을 추가했습니다. (Permit All)
401, 403 예외에 대한 핸들링을 추가했습니다. 

### 스웨거 설정 추가
개발 서버 정보를 추가했습니다.

### 그 외
헬스 체크 API를 추가했습니다. 
파라미터 스토어 정보를 추가했습니다.
암호화된 개발서버 yml 파일을 추가했습니다.

## 참고 사항

## 관련 이슈
- #35

