### PR TITLE
FEAT : 주문 내역 테이블 추가

### DIFF
--- a/src/main/java/com/zb/fresh_api/domain/entity/address/DeliveryAddress.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/address/DeliveryAddress.java
@@ -1,0 +1,45 @@
+package com.zb.fresh_api.domain.entity.address;
+
+import com.zb.fresh_api.domain.entity.base.BaseTimeEntity;
+import com.zb.fresh_api.domain.entity.member.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(
+        name = "delivery_address"
+)
+public class DeliveryAddress extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", columnDefinition = "BIGINT UNSIGNED comment '배송지 고유 번호'")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false, columnDefinition = "BIGINT UNSIGNED comment '회원 고유 번호'")
+    private Member member;
+
+    @Column(name = "recipient_name", nullable = false, columnDefinition = "varchar(50) comment '받는 사람 이름'")
+    private String recipientName;
+
+    @Column(name = "phone", nullable = false, columnDefinition = "varchar(20) comment '전화번호'")
+    private String phone;
+
+    @Column(name = "address", nullable = false, columnDefinition = "varchar(255) comment '주소'")
+    private String address;
+
+    @Column(name = "detailed_address", columnDefinition = "varchar(255) comment '상세 주소'")
+    private String detailedAddress;
+
+    @Column(name = "postal_code", nullable = false, columnDefinition = "varchar(10) comment '우편번호'")
+    private String postalCode;
+
+    @Column(name = "is_default", columnDefinition = "TINYINT(1) comment '기본 배송지 여부'")
+    private Boolean isDefault;
+
+}

--- a/src/main/java/com/zb/fresh_api/domain/entity/address/DeliveryAddressSnapshot.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/address/DeliveryAddressSnapshot.java
@@ -1,0 +1,57 @@
+package com.zb.fresh_api.domain.entity.address;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(
+        name = "delivery_address_snapshot"
+)
+public class DeliveryAddressSnapshot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", columnDefinition = "BIGINT UNSIGNED comment '배송지 스냅샷 고유 번호'")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "delivery_address_id", columnDefinition = "BIGINT UNSIGNED comment '배송지 고유 번호'")
+    private DeliveryAddress deliveryAddress;
+
+    @Column(name = "recipient_name", nullable = false, columnDefinition = "varchar(50) comment '받는 사람 이름'")
+    private String recipientName;
+
+    @Column(name = "phone", nullable = false, columnDefinition = "varchar(20) comment '전화번호'")
+    private String phone;
+
+    @Column(name = "address", nullable = false, columnDefinition = "varchar(255) comment '주소'")
+    private String address;
+
+    @Column(name = "detailed_address", columnDefinition = "varchar(255) comment '상세 주소'")
+    private String detailedAddress;
+
+    @Column(name = "postal_code", nullable = false, columnDefinition = "varchar(10) comment '우편번호'")
+    private String postalCode;
+
+    @Builder.Default
+    @Column(name = "created_at", updatable = false, columnDefinition = "datetime comment '스냅샷 생성 일시'")
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    public static DeliveryAddressSnapshot of(DeliveryAddress deliveryAddress) {
+        return DeliveryAddressSnapshot.builder()
+                .deliveryAddress(deliveryAddress)
+                .recipientName(deliveryAddress.getRecipientName())
+                .phone(deliveryAddress.getPhone())
+                .address(deliveryAddress.getAddress())
+                .detailedAddress(deliveryAddress.getDetailedAddress())
+                .postalCode(deliveryAddress.getPostalCode())
+                .build();
+    }
+
+}

--- a/src/main/java/com/zb/fresh_api/domain/entity/member/Customer.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/member/Customer.java
@@ -1,0 +1,44 @@
+package com.zb.fresh_api.domain.entity.member;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(
+        name = "customer"
+)
+public class Customer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", columnDefinition = "BIGINT UNSIGNED comment '고유 번호'")
+    private Long id;
+
+    @Column(name = "email", nullable = false, columnDefinition = "varchar(255) comment '이메일'")
+    private String email;
+
+    @Column(name = "nickname", nullable = false, columnDefinition = "varchar(20) comment '닉네임'")
+    private String nickname;
+
+    @Column(name = "phone", columnDefinition = "varchar(20) comment '전화번호'")
+    private String phone;
+
+    @Builder.Default
+    @Column(name = "created_at", columnDefinition = "datetime comment '생성일'")
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    public static Customer of(Member member){
+        return Customer.builder()
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .phone(member.getPhone())
+                .build();
+    }
+
+}

--- a/src/main/java/com/zb/fresh_api/domain/entity/order/Order.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/order/Order.java
@@ -1,0 +1,41 @@
+package com.zb.fresh_api.domain.entity.order;
+
+import com.zb.fresh_api.domain.entity.address.DeliveryAddressSnapshot;
+import com.zb.fresh_api.domain.entity.member.Customer;
+import com.zb.fresh_api.domain.entity.product.ProductSnapshot;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(
+        name = "order"
+)
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", columnDefinition = "BIGINT UNSIGNED comment '고유 번호'")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "customer_id", nullable = false, columnDefinition = "BIGINT UNSIGNED comment '구매자 고유 번호'")
+    private Customer customer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_snapshot_id", nullable = false, columnDefinition = "BIGINT UNSIGNED comment '상품 스냅샷 고유 번호'")
+    private ProductSnapshot productSnapshot;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "delivery_address_snapshot_id", nullable = false, columnDefinition = "BIGINT UNSIGNED comment '배송지 스냅샷 고유 번호'")
+    private DeliveryAddressSnapshot deliveryAddressSnapshot;
+
+    @Column(name = "created_at", nullable = false, columnDefinition = "varchar(20) comment '상태'")
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/zb/fresh_api/domain/entity/product/ProductSnapshot.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/product/ProductSnapshot.java
@@ -1,26 +1,11 @@
 package com.zb.fresh_api.domain.entity.product;
 
-import com.zb.fresh_api.domain.entity.category.Category;
-import com.zb.fresh_api.domain.entity.member.Member;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @Builder
@@ -32,6 +17,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 )
 @EntityListeners(AuditingEntityListener.class)
 public class ProductSnapshot {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", columnDefinition = "BIGINT UNSIGNED comment '고유 번호'")
@@ -40,14 +26,6 @@ public class ProductSnapshot {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", nullable = false, columnDefinition = "BIGINT UNSIGNED comment '상품 고유 번호'")
     private Product product;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category_id", nullable = false, columnDefinition = "BIGINT UNSIGNED comment '카테고리 고유 번호'")
-    private Category category;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false, columnDefinition = "BIGINT UNSIGNED comment '회원 고유 번호'")
-    private Member member;
 
     @JoinColumn(name = "name", nullable = false, columnDefinition = "varchar(20)  comment '상품명'")
     private String name;
@@ -58,19 +36,17 @@ public class ProductSnapshot {
     @Column(name = "price", nullable = false, precision = 10, scale = 2, columnDefinition = "DECIMAL(10,2) comment '가격'")
     private BigDecimal price;
 
-    @CreatedDate
-    @Column(name = "snapshot_date", updatable = false, columnDefinition = "datetime comment '스냅샷 생성 일시'")
-    private LocalDateTime snapshotDate;
+    @Builder.Default
+    @Column(name = "created_at", updatable = false, columnDefinition = "datetime comment '스냅샷 생성 일시'")
+    private LocalDateTime createdAt = LocalDateTime.now();
 
     public static ProductSnapshot create(Product product) {
-        return  ProductSnapshot.builder()
-            .product(product)
-            .category(product.getCategory())
-            .member(product.getMember())
-            .name(product.getName())
-            .description(product.getDescription())
-            .price(product.getPrice())
-            .build();
+        return ProductSnapshot.builder()
+                .product(product)
+                .name(product.getName())
+                .description(product.getDescription())
+                .price(product.getPrice())
+                .build();
     }
 
 }


### PR DESCRIPTION
## 작업
주문 내역을 작성하기 위한 Entity를 추가했습니다.
- 주문 내역 엔티티
- 배송지 엔티티
- 배송지 스냅샷 엔티티
- 상품 스냅샷 엔티티
- 구매자 정보 

주문 내역 - 상품 스냅샷 - 상품 (판매자 정보 포함)
주문 내역 - 배송지 스냅샷 - 배송지 정보 (구매자가 입력한 배송지 정보)
구매자 - 회원 정보

## 참고 사항
배송지 정보의 Member 정보를 포함하고 있어 Customer 정보의 Member 정보를 빼려고했으나 Customer와 배송지 정보는 연관이 없다고 생각되어 추가했습니다.

## 관련 이슈
- Close #이슈번호
