### PR TITLE
FEAT : 회원 배송지 설정 기능 추가

### DIFF
--- a/src/main/java/com/zb/fresh_api/api/config/S3Config.java
+++ b/src/main/java/com/zb/fresh_api/api/config/S3Config.java
@@ -28,7 +28,6 @@ public class S3Config {
         return S3Client.builder()
                 .credentialsProvider(provider)
                 .region(Region.of(region))
-//                .region(Region.AP_NORTHEAST_2)
                 .build();
     }
 

--- a/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
@@ -117,4 +117,27 @@ public class MemberController {
         return ApiResponse.success(ResponseCode.SUCCESS);
     }
 
+    @Operation(
+            summary = "배송지 삭제",
+            description = "배송지 정보를 삭제합니다."
+    )
+    @DeleteMapping("/delivery-addresses/{deliveryAddressId}")
+    public ResponseEntity<ApiResponse<Void>> deleteDeliveryAddress(
+            @Parameter(hidden = true) @LoginMember Member loginMember,
+            @PathVariable Long deliveryAddressId) {
+        memberService.deleteDeliveryAddress(loginMember, deliveryAddressId);
+        return ApiResponse.success(ResponseCode.SUCCESS);
+    }
+
+    @Operation(
+            summary = "배송지 전체 삭제",
+            description = "배송지 정보를 전체 삭제합니다."
+    )
+    @DeleteMapping("/delivery-addresses")
+    public ResponseEntity<ApiResponse<Void>> deleteDeliveryAddress(
+            @Parameter(hidden = true) @LoginMember Member loginMember) {
+        memberService.deleteAllDeliveryAddress(loginMember);
+        return ApiResponse.success(ResponseCode.SUCCESS);
+    }
+
 }

--- a/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
@@ -2,10 +2,7 @@ package com.zb.fresh_api.api.controller;
 
 import com.zb.fresh_api.api.annotation.LoginMember;
 import com.zb.fresh_api.api.dto.SignUpRequest;
-import com.zb.fresh_api.api.dto.request.AddDeliveryAddressRequest;
-import com.zb.fresh_api.api.dto.request.LoginRequest;
-import com.zb.fresh_api.api.dto.request.OauthLoginRequest;
-import com.zb.fresh_api.api.dto.request.UpdateProfileRequest;
+import com.zb.fresh_api.api.dto.request.*;
 import com.zb.fresh_api.api.dto.response.AddDeliveryAddressResponse;
 import com.zb.fresh_api.api.dto.response.LoginResponse;
 import com.zb.fresh_api.api.dto.response.OauthLoginResponse;
@@ -100,11 +97,24 @@ public class MemberController {
             summary = "배송지 추가",
             description = "배송지 정보를 추가합니다. (최대3개, 대표1개)"
     )
-    @PostMapping("delivery-addresses")
+    @PostMapping("/delivery-addresses")
     public ResponseEntity<ApiResponse<AddDeliveryAddressResponse>> addDeliveryAddress(
             @Parameter(hidden = true) @LoginMember Member loginMember,
             @RequestBody @Valid AddDeliveryAddressRequest request) {
         return ApiResponse.success(ResponseCode.SUCCESS, memberService.addDeliveryAddress(loginMember, request));
+    }
+
+    @Operation(
+            summary = "배송지 수정",
+            description = "배송지 정보를 수정합니다."
+    )
+    @PatchMapping("/delivery-addresses/{deliveryAddressId}")
+    public ResponseEntity<ApiResponse<Void>> modifyDeliveryAddress(
+            @Parameter(hidden = true) @LoginMember Member loginMember,
+            @PathVariable Long deliveryAddressId,
+            @RequestBody @Valid ModifyDeliveryAddressRequest request) {
+        memberService.modifyDeliveryAddress(loginMember, deliveryAddressId, request);
+        return ApiResponse.success(ResponseCode.SUCCESS);
     }
 
 }

--- a/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
@@ -2,9 +2,11 @@ package com.zb.fresh_api.api.controller;
 
 import com.zb.fresh_api.api.annotation.LoginMember;
 import com.zb.fresh_api.api.dto.SignUpRequest;
+import com.zb.fresh_api.api.dto.request.AddDeliveryAddressRequest;
 import com.zb.fresh_api.api.dto.request.LoginRequest;
 import com.zb.fresh_api.api.dto.request.OauthLoginRequest;
 import com.zb.fresh_api.api.dto.request.UpdateProfileRequest;
+import com.zb.fresh_api.api.dto.response.AddDeliveryAddressResponse;
 import com.zb.fresh_api.api.dto.response.LoginResponse;
 import com.zb.fresh_api.api.dto.response.OauthLoginResponse;
 import com.zb.fresh_api.api.service.MemberService;
@@ -48,7 +50,7 @@ public class MemberController {
             description = "이메일 가입 회원의 로그인을 진행한다."
     )
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<LoginResponse>> loginWithEmail(@Valid @RequestBody LoginRequest request) {
+    public ResponseEntity<ApiResponse<LoginResponse>> loginWithEmail(@RequestBody @Valid LoginRequest request) {
         return ApiResponse.success(ResponseCode.SUCCESS, memberService.login(request));
     }
 
@@ -57,7 +59,7 @@ public class MemberController {
             description = "카카오 로그인을 진행한다."
     )
     @PostMapping("/login/kakao")
-    public ResponseEntity<ApiResponse<OauthLoginResponse>> loginWithKakao(@Valid @RequestBody OauthLoginRequest request) {
+    public ResponseEntity<ApiResponse<OauthLoginResponse>> loginWithKakao(@RequestBody @Valid OauthLoginRequest request) {
         return ApiResponse.success(ResponseCode.SUCCESS, memberService.oauthLogin(request));
     }
 
@@ -86,13 +88,23 @@ public class MemberController {
             description = "회원의 이미지 또는 닉네임을 변경한다."
     )
     @PatchMapping(value = "/profile", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
-//    @PatchMapping(value = "/profile")
     public ResponseEntity<ApiResponse<Void>> updateProfile(
             @Parameter(hidden = true) @LoginMember Member loginMember,
             @Parameter @RequestPart(value = "request", required = false) @Valid UpdateProfileRequest request,
             @Parameter @RequestPart(value = "image", required = false) MultipartFile image) {
         memberService.updateProfile(loginMember, request, image);
         return ApiResponse.success(ResponseCode.SUCCESS);
+    }
+
+    @Operation(
+            summary = "배송지 추가",
+            description = "배송지 정보를 추가합니다. (최대3개, 대표1개)"
+    )
+    @PostMapping("delivery-addresses")
+    public ResponseEntity<ApiResponse<AddDeliveryAddressResponse>> addDeliveryAddress(
+            @Parameter(hidden = true) @LoginMember Member loginMember,
+            @RequestBody @Valid AddDeliveryAddressRequest request) {
+        return ApiResponse.success(ResponseCode.SUCCESS, memberService.addDeliveryAddress(loginMember, request));
     }
 
 }

--- a/src/main/java/com/zb/fresh_api/api/dto/request/AddDeliveryAddressRequest.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/request/AddDeliveryAddressRequest.java
@@ -1,0 +1,25 @@
+package com.zb.fresh_api.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "배송지 추가 요청")
+public record AddDeliveryAddressRequest(
+        @Schema(description = "받는 사람 이름", example = "홍길동")
+        String recipientName,
+
+        @Schema(description = "전화번호", example = "01012345678")
+        String phone,
+
+        @Schema(description = "주소", example = "경기도 광명시 철산동")
+        String address,
+
+        @Schema(description = "상세 주소", example = "땡땡 아파트 104동 705호")
+        String detailedAddress,
+
+        @Schema(description = "우편 번호", example = "14888")
+        String postalCode,
+
+        @Schema(description = "기본 배송지 여부", example = "true")
+        boolean isDefault
+) {
+}

--- a/src/main/java/com/zb/fresh_api/api/dto/request/ModifyDeliveryAddressRequest.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/request/ModifyDeliveryAddressRequest.java
@@ -1,0 +1,25 @@
+package com.zb.fresh_api.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "배송지 수정 요청")
+public record ModifyDeliveryAddressRequest(
+        @Schema(description = "받는 사람 이름", example = "홍길동")
+        String recipientName,
+
+        @Schema(description = "전화번호", example = "01012345678")
+        String phone,
+
+        @Schema(description = "주소", example = "경기도 광명시 철산동")
+        String address,
+
+        @Schema(description = "상세 주소", example = "땡땡 아파트 104동 705호")
+        String detailedAddress,
+
+        @Schema(description = "우편 번호", example = "14888")
+        String postalCode,
+
+        @Schema(description = "기본 배송지 여부", example = "true")
+        boolean isDefault
+) {
+}

--- a/src/main/java/com/zb/fresh_api/api/dto/response/AddDeliveryAddressResponse.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/response/AddDeliveryAddressResponse.java
@@ -1,0 +1,10 @@
+package com.zb.fresh_api.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "배송지 추가 응답")
+public record AddDeliveryAddressResponse(
+        @Schema(description = "설정된 배송지 개수", example = "3")
+        Long addressCount
+) {
+}

--- a/src/main/java/com/zb/fresh_api/api/service/MemberService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/MemberService.java
@@ -155,7 +155,7 @@ public class MemberService {
 
     @Transactional
     public AddDeliveryAddressResponse addDeliveryAddress(final Member member, final AddDeliveryAddressRequest request) {
-        final List<DeliveryAddress> deliveryAddresses = deliveryAddressReader.findActiveDeliveryAddressesByMemberId(member.getId());
+        final List<DeliveryAddress> deliveryAddresses = deliveryAddressReader.getActiveDeliveryAddressesByMemberId(member.getId());
         final int addressCount = deliveryAddresses.size();
 
         validateAddressCount(addressCount);
@@ -172,7 +172,7 @@ public class MemberService {
 
     @Transactional
     public void modifyDeliveryAddress(final Member member, final Long deliveryAddressId, final ModifyDeliveryAddressRequest request) {
-        final List<DeliveryAddress> deliveryAddresses = deliveryAddressReader.findActiveDeliveryAddressesByMemberId(member.getId());
+        final List<DeliveryAddress> deliveryAddresses = deliveryAddressReader.getActiveDeliveryAddressesByMemberId(member.getId());
         final DeliveryAddress deliveryAddress = deliveryAddresses.stream()
                 .filter(address -> address.getId().equals(deliveryAddressId))
                 .findFirst()
@@ -185,6 +185,18 @@ public class MemberService {
         }
 
         deliveryAddress.modify(request);
+    }
+
+    @Transactional
+    public void deleteDeliveryAddress(final Member member, final Long deliveryAddressId) {
+        final DeliveryAddress deliveryAddress = deliveryAddressReader.getActiveDeliveryAddressByIdAndMemberId(deliveryAddressId, member.getId());
+        deliveryAddress.delete();
+    }
+
+    @Transactional
+    public void deleteAllDeliveryAddress(final Member member) {
+        final List<DeliveryAddress> deliveryAddresses = deliveryAddressReader.getActiveDeliveryAddressesByMemberId(member.getId());
+        deliveryAddresses.forEach(DeliveryAddress::delete);
     }
 
     /**

--- a/src/main/java/com/zb/fresh_api/api/service/MemberService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/MemberService.java
@@ -155,7 +155,7 @@ public class MemberService {
 
     @Transactional
     public AddDeliveryAddressResponse addDeliveryAddress(final Member member, final AddDeliveryAddressRequest request) {
-        final List<DeliveryAddress> deliveryAddresses = deliveryAddressReader.getActiveDeliveryAddressesByMemberId(member.getId());
+        final List<DeliveryAddress> deliveryAddresses = deliveryAddressReader.getAllActiveDeliveryAddressByMemberId(member.getId());
         final int addressCount = deliveryAddresses.size();
 
         validateAddressCount(addressCount);
@@ -172,7 +172,7 @@ public class MemberService {
 
     @Transactional
     public void modifyDeliveryAddress(final Member member, final Long deliveryAddressId, final ModifyDeliveryAddressRequest request) {
-        final List<DeliveryAddress> deliveryAddresses = deliveryAddressReader.getActiveDeliveryAddressesByMemberId(member.getId());
+        final List<DeliveryAddress> deliveryAddresses = deliveryAddressReader.getAllActiveDeliveryAddressByMemberId(member.getId());
         final DeliveryAddress deliveryAddress = deliveryAddresses.stream()
                 .filter(address -> address.getId().equals(deliveryAddressId))
                 .findFirst()
@@ -195,7 +195,7 @@ public class MemberService {
 
     @Transactional
     public void deleteAllDeliveryAddress(final Member member) {
-        final List<DeliveryAddress> deliveryAddresses = deliveryAddressReader.getActiveDeliveryAddressesByMemberId(member.getId());
+        final List<DeliveryAddress> deliveryAddresses = deliveryAddressReader.getAllActiveDeliveryAddressByMemberId(member.getId());
         deliveryAddresses.forEach(DeliveryAddress::delete);
     }
 

--- a/src/main/java/com/zb/fresh_api/api/utils/S3Uploader.java
+++ b/src/main/java/com/zb/fresh_api/api/utils/S3Uploader.java
@@ -37,13 +37,11 @@ public class S3Uploader {
 
     public UploadedFile upload(final CategoryType category, final MultipartFile file) {
         final String key = getFilePath(category, file.getOriginalFilename());
-//        final Map<String, String> metadata = createMetadataFromFile(file);
         final PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucket)
                 .key(key)
                 .contentType(file.getContentType())
                 .contentLength(file.getSize())
-//                .metadata(metadata)
                 .acl(ObjectCannedACL.PUBLIC_READ)
                 .build();
 

--- a/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
+++ b/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
@@ -36,7 +36,6 @@ public enum ResponseCode {
     PARAM_EMAIL_NOT_VALID("1002", "입력한 이메일이 잘못되었습니다"),
     PARAM_NICKNAME_NOT_VALID("1003", "입력한 닉네임이 잘못되었습니다"),
     NOT_FOUND_MEMBER("1004", "회원 정보를 찾을 수 없습니다."),
-    EXCEEDED_DELIVERY_ADDRESS_COUNT("1005", "등록할 수 있는 배송지의 개수가 초과되었습니다. (최대 3개)"),
 
     /**
      * Terms (1100 ~ 1200)
@@ -83,7 +82,13 @@ public enum ResponseCode {
      * Product (1600 ~ 1700)
      */
     PRODUCT_NOT_FOUND("1600", "상품을 찾을 수 없습니다"),
-    NOT_PRODUCT_OWNER("1601", "수정하려는 사용자가 판매자와 일치하지 않습니다.")
+    NOT_PRODUCT_OWNER("1601", "수정하려는 사용자가 판매자와 일치하지 않습니다."),
+
+    /**
+     * Delivery (1700 ~ 1800)
+     */
+    NOT_FOUND_DELIVERY_ADDRESS("1700", "등록된 배송지 정보를 찾을 수 없습니다."),
+    EXCEEDED_DELIVERY_ADDRESS_COUNT("1701", "등록할 수 있는 배송지의 개수가 초과되었습니다. (최대 3개)"),
     ;
 
     private final String code;

--- a/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
+++ b/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
@@ -36,6 +36,7 @@ public enum ResponseCode {
     PARAM_EMAIL_NOT_VALID("1002", "입력한 이메일이 잘못되었습니다"),
     PARAM_NICKNAME_NOT_VALID("1003", "입력한 닉네임이 잘못되었습니다"),
     NOT_FOUND_MEMBER("1004", "회원 정보를 찾을 수 없습니다."),
+    EXCEEDED_DELIVERY_ADDRESS_COUNT("1005", "등록할 수 있는 배송지의 개수가 초과되었습니다. (최대 3개)"),
 
     /**
      * Terms (1100 ~ 1200)

--- a/src/main/java/com/zb/fresh_api/domain/entity/address/DeliveryAddress.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/address/DeliveryAddress.java
@@ -1,6 +1,7 @@
 package com.zb.fresh_api.domain.entity.address;
 
 import com.zb.fresh_api.api.dto.request.AddDeliveryAddressRequest;
+import com.zb.fresh_api.api.dto.request.ModifyDeliveryAddressRequest;
 import com.zb.fresh_api.domain.entity.base.BaseTimeEntity;
 import com.zb.fresh_api.domain.entity.member.Member;
 import jakarta.persistence.*;
@@ -64,5 +65,19 @@ public class DeliveryAddress extends BaseTimeEntity {
     public void cancelDefault() {
         this.isDefault = false;
     }
+
+    public void modify(final ModifyDeliveryAddressRequest dto) {
+        this.recipientName = dto.recipientName();
+        this.phone = dto.phone();
+        this.address = dto.address();
+        this.detailedAddress = dto.detailedAddress();
+        this.postalCode = dto.postalCode();
+        this.isDefault = dto.isDefault();
+    }
+
+    public void activateDefault() {
+        this.isDefault = true;
+    }
+
 
 }

--- a/src/main/java/com/zb/fresh_api/domain/entity/address/DeliveryAddress.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/address/DeliveryAddress.java
@@ -62,6 +62,10 @@ public class DeliveryAddress extends BaseTimeEntity {
                 .build();
     }
 
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
     public void cancelDefault() {
         this.isDefault = false;
     }

--- a/src/main/java/com/zb/fresh_api/domain/entity/address/DeliveryAddress.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/address/DeliveryAddress.java
@@ -1,9 +1,12 @@
 package com.zb.fresh_api.domain.entity.address;
 
+import com.zb.fresh_api.api.dto.request.AddDeliveryAddressRequest;
 import com.zb.fresh_api.domain.entity.base.BaseTimeEntity;
 import com.zb.fresh_api.domain.entity.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -40,6 +43,26 @@ public class DeliveryAddress extends BaseTimeEntity {
     private String postalCode;
 
     @Column(name = "is_default", columnDefinition = "TINYINT(1) comment '기본 배송지 여부'")
-    private Boolean isDefault;
+    private boolean isDefault;
+
+    @Column(name = "deleted_at", columnDefinition = "datetime comment '삭제 일시'")
+    private LocalDateTime deletedAt;
+
+    public static DeliveryAddress create(final Member member,
+                                         final AddDeliveryAddressRequest dto) {
+        return DeliveryAddress.builder()
+                .member(member)
+                .recipientName(dto.recipientName())
+                .phone(dto.phone())
+                .address(dto.address())
+                .detailedAddress(dto.detailedAddress())
+                .postalCode(dto.postalCode())
+                .isDefault(dto.isDefault())
+                .build();
+    }
+
+    public void cancelDefault() {
+        this.isDefault = false;
+    }
 
 }

--- a/src/main/java/com/zb/fresh_api/domain/entity/category/Category.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/category/Category.java
@@ -28,7 +28,7 @@ public class Category extends BaseTimeEntity {
     private Category parent;
 
     @Column(name="is_used", nullable = false, columnDefinition = "BOOLEAN comment '사용 여부'")
-    private Boolean isUsed;
+    private boolean isUsed;
 
     @Column(name = "name", nullable = false, columnDefinition = "varchar(20) comment '카테고리명'")
     private String name;

--- a/src/main/java/com/zb/fresh_api/domain/entity/order/ProductOrder.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/order/ProductOrder.java
@@ -14,9 +14,9 @@ import java.time.LocalDateTime;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
 @Table(
-        name = "order"
+        name = "product_order"
 )
-public class Order {
+public class ProductOrder {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/zb/fresh_api/domain/repository/jpa/DeliveryAddressJpaRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/jpa/DeliveryAddressJpaRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface DeliveryAddressJpaRepository extends JpaRepository<DeliveryAddress, Long> {
 
     List<DeliveryAddress> findAllByMemberIdAndDeletedAtIsNull(Long memberId);
+
 }

--- a/src/main/java/com/zb/fresh_api/domain/repository/jpa/DeliveryAddressJpaRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/jpa/DeliveryAddressJpaRepository.java
@@ -4,9 +4,12 @@ import com.zb.fresh_api.domain.entity.address.DeliveryAddress;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DeliveryAddressJpaRepository extends JpaRepository<DeliveryAddress, Long> {
 
     List<DeliveryAddress> findAllByMemberIdAndDeletedAtIsNull(Long memberId);
+
+    Optional<DeliveryAddress> findByIdAndMemberIdAndDeletedAtIsNull(final Long id, final Long memberId);
 
 }

--- a/src/main/java/com/zb/fresh_api/domain/repository/jpa/DeliveryAddressJpaRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/jpa/DeliveryAddressJpaRepository.java
@@ -1,0 +1,11 @@
+package com.zb.fresh_api.domain.repository.jpa;
+
+import com.zb.fresh_api.domain.entity.address.DeliveryAddress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DeliveryAddressJpaRepository extends JpaRepository<DeliveryAddress, Long> {
+
+    List<DeliveryAddress> findAllByMemberIdAndDeletedAtIsNull(Long memberId);
+}

--- a/src/main/java/com/zb/fresh_api/domain/repository/query/DeliveryAddressQueryRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/query/DeliveryAddressQueryRepository.java
@@ -1,0 +1,17 @@
+package com.zb.fresh_api.domain.repository.query;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zb.fresh_api.domain.entity.address.QDeliveryAddress;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DeliveryAddressQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    QDeliveryAddress deliveryAddress = QDeliveryAddress.deliveryAddress;
+
+
+}

--- a/src/main/java/com/zb/fresh_api/domain/repository/reader/DeliveryAddressReader.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/reader/DeliveryAddressReader.java
@@ -17,7 +17,7 @@ public class DeliveryAddressReader {
     private final DeliveryAddressJpaRepository deliveryAddressJpaRepository;
     private final DeliveryAddressQueryRepository deliveryAddressQueryRepository;
 
-    public List<DeliveryAddress> getActiveDeliveryAddressesByMemberId(Long memberId) {
+    public List<DeliveryAddress> getAllActiveDeliveryAddressByMemberId(Long memberId) {
         return deliveryAddressJpaRepository.findAllByMemberIdAndDeletedAtIsNull(memberId);
     }
 

--- a/src/main/java/com/zb/fresh_api/domain/repository/reader/DeliveryAddressReader.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/reader/DeliveryAddressReader.java
@@ -15,7 +15,8 @@ public class DeliveryAddressReader {
     private final DeliveryAddressJpaRepository deliveryAddressJpaRepository;
     private final DeliveryAddressQueryRepository deliveryAddressQueryRepository;
 
-    public List<DeliveryAddress> findActiveDeliveryAddressesByMember(Long memberId) {
+    public List<DeliveryAddress> findActiveDeliveryAddressesByMemberId(Long memberId) {
         return deliveryAddressJpaRepository.findAllByMemberIdAndDeletedAtIsNull(memberId);
     }
+
 }

--- a/src/main/java/com/zb/fresh_api/domain/repository/reader/DeliveryAddressReader.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/reader/DeliveryAddressReader.java
@@ -1,0 +1,21 @@
+package com.zb.fresh_api.domain.repository.reader;
+
+import com.zb.fresh_api.domain.annotation.Reader;
+import com.zb.fresh_api.domain.entity.address.DeliveryAddress;
+import com.zb.fresh_api.domain.repository.jpa.DeliveryAddressJpaRepository;
+import com.zb.fresh_api.domain.repository.query.DeliveryAddressQueryRepository;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Reader
+@RequiredArgsConstructor
+public class DeliveryAddressReader {
+
+    private final DeliveryAddressJpaRepository deliveryAddressJpaRepository;
+    private final DeliveryAddressQueryRepository deliveryAddressQueryRepository;
+
+    public List<DeliveryAddress> findActiveDeliveryAddressesByMember(Long memberId) {
+        return deliveryAddressJpaRepository.findAllByMemberIdAndDeletedAtIsNull(memberId);
+    }
+}

--- a/src/main/java/com/zb/fresh_api/domain/repository/reader/DeliveryAddressReader.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/reader/DeliveryAddressReader.java
@@ -1,5 +1,7 @@
 package com.zb.fresh_api.domain.repository.reader;
 
+import com.zb.fresh_api.common.exception.CustomException;
+import com.zb.fresh_api.common.exception.ResponseCode;
 import com.zb.fresh_api.domain.annotation.Reader;
 import com.zb.fresh_api.domain.entity.address.DeliveryAddress;
 import com.zb.fresh_api.domain.repository.jpa.DeliveryAddressJpaRepository;
@@ -15,8 +17,13 @@ public class DeliveryAddressReader {
     private final DeliveryAddressJpaRepository deliveryAddressJpaRepository;
     private final DeliveryAddressQueryRepository deliveryAddressQueryRepository;
 
-    public List<DeliveryAddress> findActiveDeliveryAddressesByMemberId(Long memberId) {
+    public List<DeliveryAddress> getActiveDeliveryAddressesByMemberId(Long memberId) {
         return deliveryAddressJpaRepository.findAllByMemberIdAndDeletedAtIsNull(memberId);
+    }
+
+    public DeliveryAddress getActiveDeliveryAddressByIdAndMemberId(Long id, Long memberId) {
+        return deliveryAddressJpaRepository.findByIdAndMemberIdAndDeletedAtIsNull(id, memberId)
+                .orElseThrow(() -> new CustomException(ResponseCode.NOT_FOUND_DELIVERY_ADDRESS));
     }
 
 }

--- a/src/main/java/com/zb/fresh_api/domain/repository/writer/DeliveryAddressWriter.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/writer/DeliveryAddressWriter.java
@@ -1,0 +1,17 @@
+package com.zb.fresh_api.domain.repository.writer;
+
+import com.zb.fresh_api.domain.annotation.Writer;
+import com.zb.fresh_api.domain.entity.address.DeliveryAddress;
+import com.zb.fresh_api.domain.repository.jpa.DeliveryAddressJpaRepository;
+import lombok.RequiredArgsConstructor;
+
+@Writer
+@RequiredArgsConstructor
+public class DeliveryAddressWriter {
+
+    private final DeliveryAddressJpaRepository deliveryAddressJpaRepository;
+
+    public DeliveryAddress store(final DeliveryAddress deliveryAddress) {
+        return deliveryAddressJpaRepository.save(deliveryAddress);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,7 +5,7 @@ spring:
   config:
     activate:
       on-profile: dev
-#    import: aws-parameterstore:/param/fresh2you_dev/
+    import: aws-parameterstore:/param/fresh2you_${spring.profiles.active}/
 
   security:
     oauth2:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
-spring:
-  config:
-    import: aws-parameterstore:/param/fresh2you_${spring.profiles.active}/
+#spring:
+#  config:
+#    import: aws-parameterstore:/param/fresh2you_${spring.profiles.active}/
 
 springdoc:
   api-docs:

--- a/src/test/java/com/zb/fresh_api/api/service/MemberServiceTest.java
+++ b/src/test/java/com/zb/fresh_api/api/service/MemberServiceTest.java
@@ -83,7 +83,31 @@ class MemberServiceTest extends ServiceTest {
     @Test
     @DisplayName("배송지 삭제 - 성공")
     void 배송지_삭제_성공() {
+        // given
+        Member member = getConstructorMonkey().giveMeBuilder(Member.class)
+                .set("id", Arbitraries.longs().greaterOrEqual(1))
+                .set("email", Arbitraries.strings().alpha().ofMinLength(4).ofMaxLength(8).map(param -> param + "@gmail.com"))
+                .set("phone", Arbitraries.strings().numeric().ofLength(11))
+                .set("provider", Arbitraries.of(Provider.class).sample())
+                .set("role", MemberRole.ROLE_USER)
+                .sample();
 
+        Long deliveryAddressId = Arbitraries.longs().between(1, 10).sample();
+
+        DeliveryAddress deliveryAddress = getBuilderMonkey().giveMeBuilder(DeliveryAddress.class)
+                .set("id", deliveryAddressId)
+                .set("member", member)
+                .set("isDefault", false)
+                .sample();
+
+        // when
+        doReturn(deliveryAddress).when(deliveryAddressReader).getActiveDeliveryAddressByIdAndMemberId(deliveryAddressId, member.getId());
+
+        // then
+        memberService.deleteDeliveryAddress(member, deliveryAddressId);
+
+        assertNotNull(deliveryAddress.getDeletedAt());
+        verify(deliveryAddressReader, times(1)).getActiveDeliveryAddressByIdAndMemberId(deliveryAddressId, member.getId());
     }
 
     @Test

--- a/src/test/java/com/zb/fresh_api/common/base/ServiceTest.java
+++ b/src/test/java/com/zb/fresh_api/common/base/ServiceTest.java
@@ -1,6 +1,7 @@
 package com.zb.fresh_api.common.base;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
 import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
@@ -41,6 +42,13 @@ public abstract class ServiceTest {
         return FixtureMonkey.builder()
                 .plugin(new JakartaValidationPlugin())
                 .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+                .build();
+    }
+
+    protected final FixtureMonkey getBuilderMonkey() {
+        return FixtureMonkey.builder()
+                .plugin(new JakartaValidationPlugin())
+                .objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
                 .build();
     }
 


### PR DESCRIPTION
## 작업
로그인한 회원의 배송지 등록, 수정, 삭제 기능을 구현합니다.
- 회원은 배송지를 등록할 경우, 최대 3개까지 등록이 가능합니다.
- 회원이 기본 배송지로 선택하여 등록할 경우, 기존 기본 배송지는 해제됩니다.
- 회원이 배송지를 수정할 때 기본 배송지로 선택할 경우, 기존 기본 배송지는 해제됩니다.
- 회원이 배송지를 삭제할 경우, 데이터를 삭제하는 것이 아닌 deleted_at 칼럼을 등록합니다.
  - 데이터를 삭제처리 하지 않는 이유는 스냅샷 데이터가 배송지 정보와 관계를 맺고 있어 칼럼으로 관리합니다.
- **기본 배송지는 존재하지 않을수도 있습니다.**

## 참고 사항

## 관련 이슈
- Close #42 
