### PR TITLE
FEAT : 배송지 목록 조회 API 

### DIFF
--- a/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
@@ -10,6 +10,7 @@ import com.zb.fresh_api.api.dto.request.OauthLoginRequest;
 import com.zb.fresh_api.api.dto.request.UpdateProfileRequest;
 import com.zb.fresh_api.api.dto.response.AddDeliveryAddressResponse;
 import com.zb.fresh_api.api.dto.response.ChargePointResponse;
+import com.zb.fresh_api.api.dto.response.GetAllAddressResponse;
 import com.zb.fresh_api.api.dto.response.LoginResponse;
 import com.zb.fresh_api.api.dto.response.OauthLoginResponse;
 import com.zb.fresh_api.api.service.MemberService;
@@ -167,6 +168,19 @@ public class MemberController {
         ChargePointResponse chargePointResponse = memberService.chargePoint(request,
             loginMember.getId());
         return ApiResponse.success(ResponseCode.SUCCESS,chargePointResponse);
+    }
+
+    @Operation(
+        summary = "배송지 목록 조회",
+        description = "자신의 배송지 목록을 조회합니다"
+    )
+    @GetMapping("/delivery-addresses")
+    public ResponseEntity<ApiResponse<GetAllAddressResponse>> getDeliveryAddresses(
+        @Parameter(hidden = true) @LoginMember Member loginMember
+    ){
+        GetAllAddressResponse response = memberService.getAllAddress(loginMember.getId());
+        return ApiResponse.success(ResponseCode.SUCCESS,response);
+
     }
 
 }

--- a/src/main/java/com/zb/fresh_api/api/dto/response/AddressDto.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/response/AddressDto.java
@@ -1,0 +1,22 @@
+package com.zb.fresh_api.api.dto.response;
+
+import com.zb.fresh_api.domain.entity.address.DeliveryAddress;
+
+public record AddressDto(
+    Long deliveryAddressId,
+
+    String recipientName,
+
+    String address,
+
+    String detailedAddress,
+
+    String postalCode,
+
+    boolean isDefault
+) {
+    public static AddressDto fromEntity(DeliveryAddress address) {
+        return new AddressDto(address.getId(),address.getRecipientName(), address.getAddress(),
+            address.getDetailedAddress(), address.getPostalCode(), address.isDefault());
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/dto/response/GetAllAddressResponse.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/response/GetAllAddressResponse.java
@@ -1,0 +1,15 @@
+package com.zb.fresh_api.api.dto.response;
+
+import com.zb.fresh_api.domain.entity.address.DeliveryAddress;
+import java.util.List;
+
+public record GetAllAddressResponse(
+    List<AddressDto> addressList
+) {
+
+    public static GetAllAddressResponse fromEntities(List<DeliveryAddress> list){
+        return new GetAllAddressResponse(list.stream().map(AddressDto::fromEntity).toList());
+    }
+
+
+}

--- a/src/main/java/com/zb/fresh_api/api/service/MemberService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/MemberService.java
@@ -4,6 +4,7 @@ import com.zb.fresh_api.api.dto.TermsAgreementDto;
 import com.zb.fresh_api.api.dto.request.*;
 import com.zb.fresh_api.api.dto.response.AddDeliveryAddressResponse;
 import com.zb.fresh_api.api.dto.response.ChargePointResponse;
+import com.zb.fresh_api.api.dto.response.GetAllAddressResponse;
 import com.zb.fresh_api.api.dto.response.LoginResponse;
 import com.zb.fresh_api.api.dto.response.OauthLoginResponse;
 import com.zb.fresh_api.api.factory.OauthProviderFactory;
@@ -146,7 +147,6 @@ public class MemberService {
         Member member = memberWriter.store(
             Member.create(nickName, email, passwordEncoder.encode(password), provider, providerId,
                 MemberRole.ROLE_USER, MemberStatus.ACTIVE));
-
         processTermsAgreements(termsAgreementDtos, member);
         Point point = pointWriter.store(
             Point.create(member, BigDecimal.valueOf(500), PointStatus.ACTIVE)
@@ -282,5 +282,12 @@ public class MemberService {
         point.charge(request.point());
 
         return new ChargePointResponse(request.point(), point.getBalance());
+    }
+    public GetAllAddressResponse getAllAddress(Long memberId) {
+        Member member = memberReader.getById(memberId);
+        List<DeliveryAddress> deliveryAddressList = deliveryAddressReader.getAllActiveDeliveryAddressByMemberId(
+            memberId);
+
+        return GetAllAddressResponse.fromEntities(deliveryAddressList);
     }
 }

--- a/src/test/java/com/zb/fresh_api/api/service/MemberServiceTest.java
+++ b/src/test/java/com/zb/fresh_api/api/service/MemberServiceTest.java
@@ -22,6 +22,7 @@ import com.zb.fresh_api.api.dto.request.ModifyDeliveryAddressRequest;
 import com.zb.fresh_api.api.dto.request.OauthLoginRequest;
 import com.zb.fresh_api.api.dto.response.AddDeliveryAddressResponse;
 import com.zb.fresh_api.api.dto.response.ChargePointResponse;
+import com.zb.fresh_api.api.dto.response.GetAllAddressResponse;
 import com.zb.fresh_api.api.dto.response.OauthLoginResponse;
 import com.zb.fresh_api.api.factory.OauthProviderFactory;
 import com.zb.fresh_api.common.base.ServiceTest;
@@ -575,6 +576,27 @@ class MemberServiceTest extends ServiceTest {
         assertEquals(response.balance(), request.point().add(pointBalance));
         assertEquals(response.chargePoint(), request.point());
         verify(pointHistoryWriter, times(1)).store(any(PointHistory.class));
+    }
+
+    @Test
+    @DisplayName("배송지 목록 조회")
+    void getAllAddress_success(){
+        // given
+        Member member = getMember();
+        List<DeliveryAddress> deliveryList = new ArrayList<>(List.of(
+            getConstructorMonkey().giveMeBuilder(DeliveryAddress.class).set("member", member).sample(),
+            getConstructorMonkey().giveMeBuilder(DeliveryAddress.class).set("member", member).sample(),
+            getConstructorMonkey().giveMeBuilder(DeliveryAddress.class).set("member", member).sample()
+        ));
+        doReturn(deliveryList).when(deliveryAddressReader).getAllActiveDeliveryAddressByMemberId(member.getId());
+
+        // when
+        GetAllAddressResponse response = memberService.getAllAddress(member.getId());
+
+        // then
+        assertNotNull(response);
+        assertEquals(response.addressList().size(), deliveryList.size());
+        verify(deliveryAddressReader, times(1)).getAllActiveDeliveryAddressByMemberId(member.getId());
     }
 }
 

--- a/src/test/java/com/zb/fresh_api/api/service/MemberServiceTest.java
+++ b/src/test/java/com/zb/fresh_api/api/service/MemberServiceTest.java
@@ -93,8 +93,7 @@ class MemberServiceTest extends ServiceTest {
     private PointWriter pointWriter;
 
     @Mock
-    private PointReader pointReader;
-
+    private PointReader  pointReader;
     @Mock
     private PointHistoryWriter pointHistoryWriter;
 


### PR DESCRIPTION
## 작업

1. 배송지 목록 조회 API추가하였습니다
  *  member 고유번호를 통해 배송지를 조회합니다
## 참고 사항

## 관련 이슈
- Close #50 
