### PR TITLE
FEAT : 추천 서비스 개발

### DIFF
--- a/src/main/java/com/zb/fresh_api/api/controller/RecommendController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/RecommendController.java
@@ -1,0 +1,42 @@
+package com.zb.fresh_api.api.controller;
+
+import com.zb.fresh_api.api.annotation.LoginMember;
+import com.zb.fresh_api.api.dto.request.LoadProductRecommendListRequest;
+import com.zb.fresh_api.api.dto.response.LoadProductRecommendListResponse;
+import com.zb.fresh_api.api.service.RecommendService;
+import com.zb.fresh_api.common.exception.ResponseCode;
+import com.zb.fresh_api.common.response.ApiResponse;
+import com.zb.fresh_api.domain.entity.member.Member;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+        name = "사용자 API",
+        description = "사용자와 관련된 API"
+)
+@RestController
+@RequestMapping("/v1/api/recommendations")
+@RequiredArgsConstructor
+public class RecommendController {
+
+    private final RecommendService recommendService;
+
+    @Operation(
+            summary = "사용자 기반 추천 서비스",
+            description = "사용자의 주문 내역을 기반으로 상품을 추천합니다."
+    )
+    @GetMapping("/order-history")
+    public ResponseEntity<ApiResponse<LoadProductRecommendListResponse>> loadProductRecommendList(
+            @Parameter(hidden = true) @LoginMember Member loginMember,
+            @Valid LoadProductRecommendListRequest request
+    ) {
+        return ApiResponse.success(ResponseCode.SUCCESS, recommendService.loadRecommendedProductList(loginMember, request));
+    }
+}

--- a/src/main/java/com/zb/fresh_api/api/dto/request/LoadProductRecommendListRequest.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/request/LoadProductRecommendListRequest.java
@@ -1,0 +1,17 @@
+package com.zb.fresh_api.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "상품 추천 서비스 요청")
+public record LoadProductRecommendListRequest(
+
+        @Min(value = 1, message = "노출 가능한 목록의 개수는 최소 1개입니다.")
+        @Max(value = 10, message = "노출 가능한 목록의 개수는 최대 10개입니다.")
+        @NotNull(message = "노출 가능 목록이 누락되었습니다.")
+        @Schema(description = "노출 가능한 목록의 개수")
+        int size
+) {
+}

--- a/src/main/java/com/zb/fresh_api/api/dto/response/LoadProductRecommendListResponse.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/response/LoadProductRecommendListResponse.java
@@ -1,0 +1,17 @@
+package com.zb.fresh_api.api.dto.response;
+
+import com.zb.fresh_api.domain.dto.recommend.RecommendProductSummary;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "상품 추천 서비스 응답")
+public record LoadProductRecommendListResponse(
+
+        @Schema(description = "상품 목록")
+        List<RecommendProductSummary> products,
+
+        @Schema(description = "상품 개수")
+        int count
+) {
+}

--- a/src/main/java/com/zb/fresh_api/api/service/RecommendService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/RecommendService.java
@@ -1,0 +1,43 @@
+package com.zb.fresh_api.api.service;
+
+import com.zb.fresh_api.api.dto.request.LoadProductRecommendListRequest;
+import com.zb.fresh_api.api.dto.response.LoadProductRecommendListResponse;
+import com.zb.fresh_api.domain.dto.recommend.RecommendProductSummary;
+import com.zb.fresh_api.domain.entity.member.Member;
+import com.zb.fresh_api.domain.repository.reader.OrderReader;
+import com.zb.fresh_api.domain.repository.reader.ProductReader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RecommendService {
+
+    private final OrderReader orderReader;
+    private final ProductReader productReader;
+
+    @Transactional(readOnly = true)
+    public LoadProductRecommendListResponse loadRecommendedProductList(final Member member,
+                                                                       final LoadProductRecommendListRequest request) {
+        // 1. 상품 구매 여부
+        final List<RecommendProductSummary> products;
+        final boolean hasProductOrder = orderReader.existsProductOrderByMemberId(member);
+
+        if (!hasProductOrder) {
+            // 1. 구매 이력이 없을 경우, 랜덤 출력 조건 추가
+            products = productReader.getAllRandomProduct(request.size());
+        } else {
+            // 2. 구매 이력이 있을 경우, 카테고리 및 판매자 상품 비율로 출력
+            products = productReader.getAllRecommendProduct(member, request.size());
+        }
+
+
+        return new LoadProductRecommendListResponse(products, products.size());
+    }
+
+}

--- a/src/main/java/com/zb/fresh_api/api/service/RecommendService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/RecommendService.java
@@ -36,7 +36,6 @@ public class RecommendService {
             products = productReader.getAllRecommendProduct(member, request.size());
         }
 
-
         return new LoadProductRecommendListResponse(products, products.size());
     }
 

--- a/src/main/java/com/zb/fresh_api/common/constants/SecurityConstants.java
+++ b/src/main/java/com/zb/fresh_api/common/constants/SecurityConstants.java
@@ -46,7 +46,12 @@ public class SecurityConstants {
             /**
              * Recommend
             */
-            "/v1/api/recommendations/**"
+            "/v1/api/recommendations/**",
+
+            /**
+             * Auth
+            */
+            "/v1/api/auth/**"
     };
 
     public static final String[] PUBLIC_URLS = {

--- a/src/main/java/com/zb/fresh_api/domain/dto/recommend/CategoryProductOrder.java
+++ b/src/main/java/com/zb/fresh_api/domain/dto/recommend/CategoryProductOrder.java
@@ -1,0 +1,14 @@
+package com.zb.fresh_api.domain.dto.recommend;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "카테고리별 구매 이력 조회")
+public record CategoryProductOrder(
+
+        @Schema(description = "카테고리 고유 번호")
+        Long categoryId,
+
+        @Schema(description = "구매 횟수")
+        Long count
+) {
+}

--- a/src/main/java/com/zb/fresh_api/domain/dto/recommend/RecommendProductSummary.java
+++ b/src/main/java/com/zb/fresh_api/domain/dto/recommend/RecommendProductSummary.java
@@ -1,0 +1,28 @@
+package com.zb.fresh_api.domain.dto.recommend;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+
+@Schema(description = "상품 추천 목록 조회시 사용되는 상품 정보")
+public record RecommendProductSummary(
+
+        @Schema(description = "상품명")
+        String productName,
+
+        @Schema(description = "상품 썸네일")
+        String productImage,
+
+        @Schema(description = "판매자명")
+        String sellerName,
+
+        @Schema(description = "판매 가격")
+        BigDecimal price,
+
+        @Schema(description = "설명 (최대 20글자)")
+        String description
+
+//        @Schema(description = "상품 설명 글자 제한 초과 여부")
+//        boolean descriptionLengthExceeded
+) {
+}

--- a/src/main/java/com/zb/fresh_api/domain/dto/recommend/SellerProductOrder.java
+++ b/src/main/java/com/zb/fresh_api/domain/dto/recommend/SellerProductOrder.java
@@ -1,0 +1,14 @@
+package com.zb.fresh_api.domain.dto.recommend;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "판매자별 구매 이력 조회")
+public record SellerProductOrder(
+
+        @Schema(description = "판매자 회원 고유 번호")
+        Long sellerId,
+
+        @Schema(description = "구매 횟수")
+        Long count
+) {
+}

--- a/src/main/java/com/zb/fresh_api/domain/entity/address/DeliveryAddress.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/address/DeliveryAddress.java
@@ -83,5 +83,4 @@ public class DeliveryAddress extends BaseTimeEntity {
         this.isDefault = true;
     }
 
-
 }

--- a/src/main/java/com/zb/fresh_api/domain/entity/product/Product.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/product/Product.java
@@ -5,22 +5,11 @@ import com.zb.fresh_api.api.dto.request.UpdateProductRequest;
 import com.zb.fresh_api.domain.entity.base.BaseTimeEntity;
 import com.zb.fresh_api.domain.entity.category.Category;
 import com.zb.fresh_api.domain.entity.member.Member;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.*;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
@@ -60,7 +49,7 @@ public class Product extends BaseTimeEntity {
     private String productImage;
     
     @Column(name = "deleted_at", columnDefinition = "datetime comment '삭제일'")
-    private LocalDateTime deleted_at;
+    private LocalDateTime deletedAt;
 
     public static Product create(AddProductRequest request,Category category, Member member, String productImage){
         return Product.builder()
@@ -84,7 +73,7 @@ public class Product extends BaseTimeEntity {
     }
 
     public static void delete(Product product){
-        product.deleted_at = LocalDateTime.now();
+        product.deletedAt = LocalDateTime.now();
     }
 
     public void decreaseQuantity(int quantity){

--- a/src/main/java/com/zb/fresh_api/domain/repository/query/OrderQueryRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/query/OrderQueryRepository.java
@@ -1,17 +1,24 @@
 package com.zb.fresh_api.domain.repository.query;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zb.fresh_api.domain.entity.address.QDeliveryAddress;
+import com.zb.fresh_api.domain.entity.address.QDeliveryAddressSnapshot;
+import com.zb.fresh_api.domain.entity.member.QMember;
 import com.zb.fresh_api.domain.entity.order.QProductOrder;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
 public class OrderQueryRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
+    QMember member = QMember.member;
     QProductOrder productOrder = QProductOrder.productOrder;
+    QDeliveryAddress deliveryAddress = QDeliveryAddress.deliveryAddress;
+    QDeliveryAddressSnapshot deliveryAddressSnapshot = QDeliveryAddressSnapshot.deliveryAddressSnapshot;
 
     public boolean existsByProductIdAndMemberId(Long productId, Long memberId) {
         Integer fetchOne = jpaQueryFactory
@@ -31,4 +38,17 @@ public class OrderQueryRepository {
                 .or(productOrder.productSnapshot.product.member.id.eq(memberId)))
             .fetch();
     }
+
+    public boolean existsProductOrderByMemberId(Long memberId) {
+        return jpaQueryFactory
+                .selectOne()
+                .from(deliveryAddressSnapshot)
+                .innerJoin(deliveryAddress).on(deliveryAddressSnapshot.deliveryAddress.eq(deliveryAddress))
+                .innerJoin(member).on(deliveryAddress.member.eq(member))
+                .where(
+                        member.id.eq(memberId)
+                )
+                .fetchFirst() != null;
+    }
+
 }

--- a/src/main/java/com/zb/fresh_api/domain/repository/query/ProductQueryRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/query/ProductQueryRepository.java
@@ -1,12 +1,25 @@
 package com.zb.fresh_api.domain.repository.query;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.zb.fresh_api.api.dto.request.GetAllProductByConditionsRequest;
+import com.zb.fresh_api.domain.dto.recommend.CategoryProductOrder;
+import com.zb.fresh_api.domain.dto.recommend.RecommendProductSummary;
+import com.zb.fresh_api.domain.dto.recommend.SellerProductOrder;
+import com.zb.fresh_api.domain.entity.address.QDeliveryAddress;
+import com.zb.fresh_api.domain.entity.address.QDeliveryAddressSnapshot;
+import com.zb.fresh_api.domain.entity.category.QCategory;
+import com.zb.fresh_api.domain.entity.member.QMember;
+import com.zb.fresh_api.domain.entity.order.QProductOrder;
 import com.zb.fresh_api.domain.entity.product.Product;
 import com.zb.fresh_api.domain.entity.product.QProduct;
-import java.util.List;
+import com.zb.fresh_api.domain.entity.product.QProductSnapshot;
+import com.zb.fresh_api.domain.repository.jpa.ProductOrderJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -14,13 +27,25 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @Repository
 @RequiredArgsConstructor
 public class ProductQueryRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
+    private final ProductOrderJpaRepository productOrderJpaRepository;
 
+    QMember member = QMember.member;
     QProduct product = QProduct.product;
+    QCategory category = QCategory.category;
+    QProductOrder productOrder = QProductOrder.productOrder;
+    QProductSnapshot productSnapshot = QProductSnapshot.productSnapshot;
+    QDeliveryAddress deliveryAddress = QDeliveryAddress.deliveryAddress;
+    QDeliveryAddressSnapshot deliveryAddressSnapshot = QDeliveryAddressSnapshot.deliveryAddressSnapshot;
 
     public Page<Product> findAll(GetAllProductByConditionsRequest request) {
         BooleanBuilder builder = new BooleanBuilder();
@@ -45,5 +70,147 @@ public class ProductQueryRepository {
         long total = query.fetchCount();
 
         return new PageImpl<>(products, pageable, total);
+    }
+
+    public List<RecommendProductSummary> findAllRandomProduct(int size) {
+        return jpaQueryFactory
+                .select(
+                        Projections
+                                .constructor(
+                                        RecommendProductSummary.class,
+                                        product.name,
+                                        product.productImage,
+//                                        product.member.nickname.as("sellerName"),
+                                        product.member.nickname,
+                                        product.price,
+//                                        product.description,
+                                        new CaseBuilder()
+                                                .when(product.description.length().gt(17))
+                                                .then(product.description.substring(0, 17).concat("...")) // 20글자까지 잘라서 "..." 추가
+                                                .otherwise(product.description)
+//                                        product.description.length().gt(20)
+                                ))
+                .from(product)
+                .innerJoin(member).on(product.member.eq(member))
+                .where(isNotDeleted(product))
+                .orderBy(Expressions
+                        .numberTemplate(
+                                Double.class,
+                                "function('rand')").asc()
+                )
+                .limit(size)
+                .fetch();
+    }
+
+    public List<RecommendProductSummary> findAllRecommendProduct(Long memberId, int size) {
+        // 1. 카테고리별 구매 이력 조회
+        List<CategoryProductOrder> categoryProductOrders =
+                jpaQueryFactory
+                        .select(
+                                Projections
+                                        .constructor(
+                                                CategoryProductOrder.class,
+                                                category.id,
+                                                productOrder.count().as("count")
+                                        )
+                        )
+                        .from(productOrder)
+                        .innerJoin(productSnapshot).on(productOrder.productSnapshot.eq(productSnapshot))
+                        .innerJoin(product).on(productSnapshot.product.eq(product))
+                        .innerJoin(category).on(product.category.eq(category))
+                        .innerJoin(deliveryAddressSnapshot).on(productOrder.deliveryAddressSnapshot.eq(deliveryAddressSnapshot))
+                        .innerJoin(deliveryAddress).on(deliveryAddressSnapshot.deliveryAddress.eq(deliveryAddress))
+                        .where(deliveryAddress.member.id.eq(memberId))
+                        .groupBy(QCategory.category.name)
+                        .fetch();
+
+        // 2. 판매자별 구매 이력 조회
+        List<SellerProductOrder> sellerProductOrders = jpaQueryFactory
+                .select(
+                        Projections
+                                .constructor(
+                                        SellerProductOrder.class,
+                                        member.id,
+                                        productOrder.count().as("count")
+                                )
+                )
+                .from(productOrder)
+                .innerJoin(productSnapshot).on(productOrder.productSnapshot.eq(productSnapshot))
+                .innerJoin(product).on(productSnapshot.product.eq(product))
+                .innerJoin(member).on(product.member.eq(member))
+                .innerJoin(deliveryAddressSnapshot).on(productOrder.deliveryAddressSnapshot.eq(deliveryAddressSnapshot))
+                .where(deliveryAddress.member.id.eq(memberId))
+                .groupBy(product.member.id)
+                .fetch();
+
+        // 3. 가중치 계산
+        Map<Long, Long> categoryMap = categoryProductOrders.stream()
+                .collect(Collectors.toMap(
+                        CategoryProductOrder::categoryId,
+                        CategoryProductOrder::count
+                ));
+
+        // 판매자별 가중치 (구매 이력 기반)
+        Map<Long, Long> sellerMap = sellerProductOrders.stream()
+                .collect(Collectors.toMap(
+                        SellerProductOrder::sellerId,
+                        SellerProductOrder::count
+                ));
+
+        // Step 4: 추천 상품 조회 (카테고리, 판매자 가중치를 기반으로)
+        List<RecommendProductSummary> recommendedProducts = jpaQueryFactory
+                .select(
+                        Projections
+                                .constructor(
+                                        RecommendProductSummary.class,
+                                        product.name,
+                                        product.productImage,
+                                        product.member.nickname,
+                                        product.price,
+//                                        product.description,
+                                        new CaseBuilder()
+                                                .when(product.description.length().gt(17))
+                                                .then(product.description.substring(0, 17).concat("...")) // 20글자까지 잘라서 "..." 추가
+                                                .otherwise(product.description)
+                                )
+                )
+                .from(product)
+                .leftJoin(category).on(product.category.eq(category))
+                .leftJoin(member).on(product.member.eq(member))
+                .where(
+                        isNotDeleted(product)
+                )
+                // TODO Map get() 오류 해결해야함.
+                .orderBy(
+//                        new CaseBuilder()
+//                                .when(category.id.in(categoryMap.keySet()))
+//                                .then(categoryMap.get(category.id))
+//                                .otherwise(0L).desc(),
+//                        new CaseBuilder()
+//                                .when(member.id.in(sellerMap.keySet()))
+//                                .then(sellerMap.get(member.id))
+//                                .otherwise(0L).desc()
+                        new CaseBuilder()
+                                .when(category.id.in(categoryMap.keySet()))
+                                .then(1L)
+                                .otherwise(0L).desc(),
+                        new CaseBuilder()
+                                .when(member.id.in(sellerMap.keySet()))
+                                .then(1L)
+                                .otherwise(0L).desc()
+                )
+                .limit(size * 2L)
+                .fetch();
+
+        Collections.shuffle(recommendedProducts);
+
+        return recommendedProducts.stream()
+                .limit(size)
+                .toList();
+
+    }
+
+    private BooleanExpression isNotDeleted(QProduct product) {
+        return product.deletedAt.isNull();
     }
 }

--- a/src/main/java/com/zb/fresh_api/domain/repository/reader/OrderReader.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/reader/OrderReader.java
@@ -1,10 +1,12 @@
 package com.zb.fresh_api.domain.repository.reader;
 
 import com.zb.fresh_api.domain.annotation.Reader;
+import com.zb.fresh_api.domain.entity.member.Member;
 import com.zb.fresh_api.domain.repository.jpa.OrderJpaRepository;
 import com.zb.fresh_api.domain.repository.query.OrderQueryRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 
 @Reader
 @RequiredArgsConstructor
@@ -18,5 +20,9 @@ public class OrderReader {
 
     public List<Long> findProductIdsByMemberId(Long memberId){
         return orderQueryRepository.findProductIdsByMemberId(memberId);
+    }
+
+    public boolean existsProductOrderByMemberId(Member member) {
+        return orderQueryRepository.existsProductOrderByMemberId(member.getId());
     }
 }

--- a/src/main/java/com/zb/fresh_api/domain/repository/reader/ProductReader.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/reader/ProductReader.java
@@ -1,15 +1,19 @@
 package com.zb.fresh_api.domain.repository.reader;
 
+import com.zb.fresh_api.api.dto.request.GetAllProductByConditionsRequest;
 import com.zb.fresh_api.common.exception.CustomException;
 import com.zb.fresh_api.common.exception.ResponseCode;
-import com.zb.fresh_api.api.dto.request.GetAllProductByConditionsRequest;
 import com.zb.fresh_api.domain.annotation.Reader;
+import com.zb.fresh_api.domain.dto.recommend.RecommendProductSummary;
+import com.zb.fresh_api.domain.entity.member.Member;
 import com.zb.fresh_api.domain.entity.product.Product;
 import com.zb.fresh_api.domain.repository.jpa.ProductJpaRepository;
 import com.zb.fresh_api.domain.repository.query.ProductQueryRepository;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.Optional;
 
 @Reader
 @RequiredArgsConstructor
@@ -29,5 +33,13 @@ public class ProductReader {
 
     public Page<Product> findAll(GetAllProductByConditionsRequest request){
         return productQueryRepository.findAll(request);
+    }
+
+    public List<RecommendProductSummary> getAllRandomProduct(int size) {
+        return productQueryRepository.findAllRandomProduct(size);
+    }
+
+    public List<RecommendProductSummary> getAllRecommendProduct(Member member, int size) {
+        return productQueryRepository.findAllRecommendProduct(member.getId(), size);
     }
 }

--- a/src/test/java/com/zb/fresh_api/api/service/RecommendServiceTest.java
+++ b/src/test/java/com/zb/fresh_api/api/service/RecommendServiceTest.java
@@ -1,0 +1,47 @@
+package com.zb.fresh_api.api.service;
+
+import com.zb.fresh_api.common.base.ServiceTest;
+import com.zb.fresh_api.domain.repository.reader.OrderReader;
+import com.zb.fresh_api.domain.repository.reader.ProductReader;
+import org.junit.jupiter.api.DisplayName;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+@DisplayName("상품 추천 비즈니스 로직 테스트")
+class RecommendServiceTest extends ServiceTest {
+
+    @Mock
+    private OrderReader orderReader;
+
+    @Mock
+    private ProductReader productReader;
+
+    @InjectMocks
+    private RecommendService recommendService;
+
+//    @Test
+//    void 상품_랜덤_추천() {
+//        // given
+//        LoadProductRecommendListRequest request = getConstructorMonkey().giveMeBuilder(LoadProductRecommendListRequest.class)
+//                .set("size", Arbitraries.integers().between(1, 10).sample())
+//                .sample();
+//
+//        int size = request.size();
+//
+//        List<RecommendProductSummary> productSummaries = Stream.generate(() -> getConstructorMonkey().giveMeBuilder(RecommendProductSummary.class).sample())
+//                .limit(size)
+//                .toList();
+//
+//        // when
+//        doReturn(productSummaries).when(productReader).getAllRandomProduct(size);
+//
+//        // then
+//        LoadProductRecommendListResponse response = recommendService.loadRecommendedRandomProductList(request);
+//
+//        assertNotNull(response);
+//        assertEquals(response.count(), productSummaries.size());
+//
+//        verify(productReader, times(1)).getAllRandomProduct(size);
+//    }
+
+}


### PR DESCRIPTION
## 작업
추천 서비스 기능을 개발했습니다.

- 상품의 구매 내역이 없을 경우, 전체 상품 중 랜덤 정렬을 통한 조회를 진행합니다.
- 상품의 구매 내역이 있을 경우, 구매 내역을 바탕으로 상품을 조회합니다.
  -  구매 상품의 카테고리와 개수를 그룹화하여 가중치를 부여합니다.
  - 구매 상품의 판매자와 판매 개수를 그룹화하여 가중치를 부여합니다.
  - 가중치를 바탕으로 2배의 개수를 가져와 정렬합니다.
  - 랜덤 셔플을 진행한 후 절반의 개수를 조회합니다.

## 참고 사항
- 가중치 부여를 하는 과정에서 이슈 발생(가중치 값을 부여할 수 없음)
- 가중치를 일정하게 부여(구매 내역에 포함 1, 포함하지 않음 0)
- 가중치 부여를 위한 수정 작업 필요

## 관련 이슈
- #43
