### PR TITLE
FIX : 중복 이메일 회원가입 에러 수정

### DIFF
--- a/src/main/java/com/zb/fresh_api/api/provider/TokenProvider.java
+++ b/src/main/java/com/zb/fresh_api/api/provider/TokenProvider.java
@@ -27,8 +27,8 @@ import org.springframework.util.StringUtils;
 @Component
 public class TokenProvider {
 
+    private static final String EMAIL_SEPARATOR = "|";
     public static final Long ACCESS_TOKEN_EXPIRE_TIME = Duration.ofHours(6).toMillis();
-
     private final SecretKey key;
     private final CustomUserDetailsService customUserDetailsService;
 
@@ -52,7 +52,7 @@ public class TokenProvider {
         long accessTokenExpireTime = now.getTime() + ACCESS_TOKEN_EXPIRE_TIME;
 
         return Jwts.builder()
-                .subject(email + provider.name())
+                .subject(email + EMAIL_SEPARATOR + provider.name())
                 .issuedAt(now)
                 .expiration(new Date(accessTokenExpireTime))
                 .signWith(key)

--- a/src/main/java/com/zb/fresh_api/api/provider/TokenProvider.java
+++ b/src/main/java/com/zb/fresh_api/api/provider/TokenProvider.java
@@ -6,19 +6,23 @@ import com.zb.fresh_api.common.constants.AuthConstants;
 import com.zb.fresh_api.common.exception.CustomException;
 import com.zb.fresh_api.common.exception.ResponseCode;
 import com.zb.fresh_api.domain.dto.token.Token;
-import io.jsonwebtoken.*;
+import com.zb.fresh_api.domain.enums.member.Provider;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Optional;
+import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-
-import javax.crypto.SecretKey;
-import java.time.Duration;
-import java.util.Base64;
-import java.util.Date;
-import java.util.Optional;
 
 @Component
 public class TokenProvider {
@@ -37,18 +41,18 @@ public class TokenProvider {
         this.customUserDetailsService = customUserDetailsService;
     }
 
-    public Token getTokenByEmail(String email) {
-        String accessToken = createAccessToken(email);
+    public Token getTokenByEmail(String email, Provider provider) {
+        String accessToken = createAccessToken(email, provider);
         final Date accessExpiredAt = getExpirationByToken(accessToken);
         return new Token(accessToken, accessExpiredAt);
     }
 
-    public String createAccessToken(String email) {
+    public String createAccessToken(String email, Provider provider) {
         Date now = new Date();
         long accessTokenExpireTime = now.getTime() + ACCESS_TOKEN_EXPIRE_TIME;
 
         return Jwts.builder()
-                .subject(email)
+                .subject(email + provider.name())
                 .issuedAt(now)
                 .expiration(new Date(accessTokenExpireTime))
                 .signWith(key)

--- a/src/main/java/com/zb/fresh_api/api/service/MemberService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/MemberService.java
@@ -1,14 +1,18 @@
 package com.zb.fresh_api.api.service;
 
 import com.zb.fresh_api.api.dto.TermsAgreementDto;
-import com.zb.fresh_api.api.dto.request.*;
+import com.zb.fresh_api.api.dto.request.AddDeliveryAddressRequest;
+import com.zb.fresh_api.api.dto.request.ChargePointRequest;
+import com.zb.fresh_api.api.dto.request.LoginRequest;
+import com.zb.fresh_api.api.dto.request.ModifyDeliveryAddressRequest;
+import com.zb.fresh_api.api.dto.request.OauthLoginRequest;
+import com.zb.fresh_api.api.dto.request.UpdateProfileRequest;
 import com.zb.fresh_api.api.dto.response.AddDeliveryAddressResponse;
 import com.zb.fresh_api.api.dto.response.ChargePointResponse;
 import com.zb.fresh_api.api.dto.response.GetAllAddressResponse;
 import com.zb.fresh_api.api.dto.response.LoginResponse;
 import com.zb.fresh_api.api.dto.response.OauthLoginResponse;
 import com.zb.fresh_api.api.factory.OauthProviderFactory;
-import com.zb.fresh_api.api.principal.CustomUserDetails;
 import com.zb.fresh_api.api.principal.CustomUserDetailsService;
 import com.zb.fresh_api.api.provider.TokenProvider;
 import com.zb.fresh_api.api.utils.S3Uploader;
@@ -35,19 +39,22 @@ import com.zb.fresh_api.domain.repository.reader.DeliveryAddressReader;
 import com.zb.fresh_api.domain.repository.reader.MemberReader;
 import com.zb.fresh_api.domain.repository.reader.PointReader;
 import com.zb.fresh_api.domain.repository.reader.TermsReader;
-import com.zb.fresh_api.domain.repository.writer.*;
+import com.zb.fresh_api.domain.repository.writer.DeliveryAddressWriter;
+import com.zb.fresh_api.domain.repository.writer.MemberTermsWriter;
+import com.zb.fresh_api.domain.repository.writer.MemberWriter;
+import com.zb.fresh_api.domain.repository.writer.PointHistoryWriter;
+import com.zb.fresh_api.domain.repository.writer.PointWriter;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -77,8 +84,7 @@ public class MemberService {
 
     @Transactional
     public LoginResponse login(final LoginRequest request) {
-        final CustomUserDetails userDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(request.email());
-        final Member member = userDetails.member();
+        Member member = memberReader.getByEmailAndProvider(request.email(), Provider.EMAIL);
 
         validatePassword(request.password(), member.getPassword());
 

--- a/src/main/java/com/zb/fresh_api/api/service/MemberService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/MemberService.java
@@ -89,7 +89,7 @@ public class MemberService {
         validatePassword(request.password(), member.getPassword());
 
         final LoginMember loginMember = LoginMember.fromEntity(member);
-        final Token token = tokenProvider.getTokenByEmail(request.email());
+        final Token token = tokenProvider.getTokenByEmail(request.email(), Provider.EMAIL);
         return new LoginResponse(token, loginMember);
     }
 
@@ -101,7 +101,7 @@ public class MemberService {
 
         final String email = oAuthUser.email();
         final boolean isSignup = memberReader.existsByEmailAndProvider(email, provider);
-        final Token token = resolveToken(isSignup, email);
+        final Token token = resolveToken(isSignup, email, provider);
         return new OauthLoginResponse(token, new OauthLoginMember(email, provider, oAuthUser.id()), isSignup);
     }
 
@@ -262,8 +262,8 @@ public class MemberService {
         }
     }
 
-    protected Token resolveToken(final boolean isSignup, final String email) {
-        return !isSignup ? Token.emptyToken() : tokenProvider.getTokenByEmail(email);
+    protected Token resolveToken(final boolean isSignup, final String email, Provider provider) {
+        return !isSignup ? Token.emptyToken() : tokenProvider.getTokenByEmail(email, provider);
     }
 
     private void validateAddressCount(final int addressCount) {

--- a/src/main/java/com/zb/fresh_api/domain/repository/jpa/MemberJpaRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/jpa/MemberJpaRepository.java
@@ -15,4 +15,6 @@ public interface MemberJpaRepository extends JpaRepository<Member, Long> {
     boolean existsByNicknameIgnoreCase(String nickname);
 
     boolean existsByEmailAndProvider(String email, Provider provider);
+
+    Optional<Member> findByEmailAndProvider(String email, Provider provider);
 }

--- a/src/main/java/com/zb/fresh_api/domain/repository/reader/MemberReader.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/reader/MemberReader.java
@@ -42,4 +42,9 @@ public class MemberReader {
         return memberQueryRepository.existsByPhone(phone);
     }
 
+    public Member getByEmailAndProvider(String email, Provider provider) {
+        return memberJpaRepository.findByEmailAndProvider(email, provider).orElseThrow(
+            () -> new CustomException(ResponseCode.NOT_FOUND_MEMBER)
+        );
+    }
 }


### PR DESCRIPTION
## 작업

1. 이메일 로그인 시 Provider를 포함하여 사용자를 가져오도록 변경하였습니다(다른 Provider의 중복 이메일 허용)
2. 토큰 발급 시 SUBJECT에 이메일 -> 이메일 + Provider로 변경하여 다른 Provider의 중복 이메일 토큰 공유 못하도록 설정
## 참고 사항

## 관련 이슈
- Close #58
