### PR TITLE
Feat/#26 Chatblock Entity 수정

### DIFF
--- a/src/main/java/com/zb/fresh_api/domain/entity/chat/ChatBlock.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/chat/ChatBlock.java
@@ -1,5 +1,6 @@
 package com.zb.fresh_api.domain.entity.chat;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -14,9 +15,13 @@ public class ChatBlock {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false, columnDefinition = "BIGINT UNSIGNED COMMENT 'Primary Key'")
     private Long id;
 
+    @Column(name = "chat_blocker_id", nullable = false, columnDefinition = "BIGINT COMMENT '차단한 사용자 ID'")
     private Long chatBlockerId;
+
+    @Column(name = "chat_blocked_id", nullable = false, columnDefinition = "BIGINT COMMENT '차단당한 사용자 ID'")
     private Long chatBlockedId;
 
     public static ChatBlock create(Long chatBlockerId, Long chatBlockedId) {


### PR DESCRIPTION
## 작업
ChatBlock 엔티티에서 칼럼 정의를 명확히 하고, 각 필드에 추가했습니다.

## 참고 사항
- ChatBlock 엔티티에 `chatBlockerId` 및 `chatBlockedId` 필드에 대해 `@Column` 어노테이션을 추가하여 칼럼 정의를 명확히 하였습니다.
- `NOT NULL` 제약 조건을 추가하여 데이터 무결성을 확보했습니다.
- 각 필드에 주석을 추가하여 필드의 용도를 명확히 했습니다.

## 관련 이슈
- Close #26 
