### PR TITLE
FEAT : 회원 삭제 API 추가

### DIFF
--- a/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
@@ -183,4 +183,14 @@ public class MemberController {
 
     }
 
+    @Operation(
+        summary = "회원 삭제",
+        description = "회원 삭제를 위한 API입니다"
+    )
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<ApiResponse<Void>> withdrawMember(@Parameter(hidden = true) @LoginMember Member loginMember){
+        memberService.deleteMember(loginMember.getId());
+        return ApiResponse.success(ResponseCode.SUCCESS);
+
+    }
 }

--- a/src/main/java/com/zb/fresh_api/api/service/MemberService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/MemberService.java
@@ -322,4 +322,10 @@ public class MemberService {
 
         return GetAllAddressResponse.fromEntities(deliveryAddressList);
     }
+
+    @Transactional
+    public void deleteMember(Long memberId) {
+        Member member = memberReader.getById(memberId);
+        member.delete();
+    }
 }

--- a/src/main/java/com/zb/fresh_api/domain/entity/member/Member.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/member/Member.java
@@ -114,4 +114,7 @@ public class Member extends BaseTimeEntity {
         this.sellerVerifiedAt = LocalDateTime.now();
     }
 
+    public void delete(){
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/zb/fresh_api/domain/repository/jpa/MemberJpaRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/jpa/MemberJpaRepository.java
@@ -19,4 +19,6 @@ public interface MemberJpaRepository extends JpaRepository<Member, Long> {
     boolean existsByNickname(String nickname);
 
     Optional<Member> findByEmailAndProvider(String email, Provider provider);
+
+    Optional<Member> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/com/zb/fresh_api/domain/repository/reader/MemberReader.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/reader/MemberReader.java
@@ -20,7 +20,7 @@ public class MemberReader {
     private final MemberQueryRepository memberQueryRepository;
 
     public Member getById(final Long id) {
-        return memberJpaRepository.findById(id)
+        return memberJpaRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new CustomException(ResponseCode.NOT_FOUND_MEMBER));
     }
 


### PR DESCRIPTION
## 작업

1. 멤버 삭제 API 추가
  *  실제 삭제가 아닌 deletedAt 필드 업데이트입니다
2. 멤버 삭제 API 추가에 따른 기존 멤버 ID로 검색하는 메서드 변경 
  * Jpa메서드조건에 deletedAt이 null인 조건도 추가하였습니다

## 참고 사항

## 관련 이슈
- Close #61
