### PR TITLE
FIX : 토큰 인증 시 Provider 분리 

### DIFF
--- a/src/main/java/com/zb/fresh_api/api/principal/CustomUserDetailsService.java
+++ b/src/main/java/com/zb/fresh_api/api/principal/CustomUserDetailsService.java
@@ -3,24 +3,29 @@ package com.zb.fresh_api.api.principal;
 import com.zb.fresh_api.common.exception.CustomException;
 import com.zb.fresh_api.common.exception.ResponseCode;
 import com.zb.fresh_api.domain.entity.member.Member;
+import com.zb.fresh_api.domain.enums.member.Provider;
 import com.zb.fresh_api.domain.repository.reader.MemberReader;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-import java.util.Objects;
-
 @Service
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
+    private static final String EMAIL_SEPARATOR = "|";
     private final MemberReader memberReader;
 
+    // 이 때 받은 email은 sufix가 포함되어있음
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        Member member = memberReader.getByEmail(email);
+        String[] emailAndProvider = email.split("\\" + EMAIL_SEPARATOR);
+
+        Member member = memberReader.getByEmailAndProvider(emailAndProvider[0],
+            Provider.valueOf(emailAndProvider[1].toUpperCase()));
 
         CustomUserDetails userDetails = new CustomUserDetails(member);
         validateAuthenticate(userDetails);

--- a/src/main/java/com/zb/fresh_api/domain/repository/jpa/MemberJpaRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/jpa/MemberJpaRepository.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 @Repository
 public interface MemberJpaRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByEmail(String email);
 
     boolean existsByNicknameIgnoreCase(String nickname);
 

--- a/src/main/java/com/zb/fresh_api/domain/repository/reader/MemberReader.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/reader/MemberReader.java
@@ -24,8 +24,8 @@ public class MemberReader {
                 .orElseThrow(() -> new CustomException(ResponseCode.NOT_FOUND_MEMBER));
     }
 
-    public Member getByEmail(String email) {
-        return memberJpaRepository.findByEmail(email)
+    public Member getByEmailAndProvider(String email, Provider provider) {
+        return memberJpaRepository.findByEmailAndProvider(email, provider)
                 .orElseThrow(() -> new CustomException(ResponseCode.NOT_FOUND_MEMBER));
     }
 


### PR DESCRIPTION
## 작업

1. 지난 
https://github.com/fresh2you/fresh-api/issues/58[fix](https://github.com/fresh2you/fresh-api/issues?q=is%3Aissue+is%3Aclosed+label%3Afix) 중복 이메인 로그인 불가 Issue에서 토큰에 Provider와 separator를 추가하였었는데

이것이 인증을 할 때 이메일로 분리하지 않아 분리하는 작업을 추가하였습니다.
이메일과 Provider를 분리하는 작업은 TokenProvider에서 해야하는 작업인데 저희 서비스 특성 상
이메일로만 사용자를 구분할 수 없고
```java
 @Override
    public UserDetails loadUserByUsername(String email)
```
오버라이드된 메서드는 인자를 하나만 입력 받기에 부득이하게 CustomUserDetailsService에서 분리하는 작업을 진행하였습니다

그리고 이메일을 통해 조회하는 로직에 Provider도 추가하였습니다
## 참고 사항

## 관련 이슈
- Close #77
