### PR TITLE
FEAT : 엘라스틱 캐시 도입 (파라미터 스토어 URL 입력) 

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -51,8 +51,8 @@ spring:
 
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${redis.host}
+      port: ${redis.port}
 
   jwt:
     secret: ${jwt.secret}


### PR DESCRIPTION
## 작업
도커 컨테이너로 사용하고 있던 레디스를 엘라스틱 캐시로 변경했습니다.
파라미터 스토어 key-value 등록을 통해 노출되지 않도록 했습니다.

## 참고 사항

## 관련 이슈
- Close #81
