### PR TITLE
FIX : 회원가입 Provider에따른 예외 처리 추가

### DIFF
--- a/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
@@ -50,7 +50,7 @@ public class MemberController {
     )
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Void>> signup(@RequestBody @Valid SignUpRequest request) {
-        memberService.signUp(request.email(), request.password(), request.nickname(), request.termsAgreements(), request.provider(), request.providerId());
+        memberService.signUp(request);
         return ApiResponse.success(ResponseCode.SUCCESS);
     }
 

--- a/src/main/java/com/zb/fresh_api/api/dto/SignUpRequest.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/SignUpRequest.java
@@ -12,10 +12,10 @@ public record SignUpRequest (
     @NotBlank(message = "아이디는 필수입니다")
     String email,
 
-    @NotBlank(message = "비밀번호는 필수입니다")
+//    @NotBlank(message = "비밀번호는 필수입니다")
     String password,
 
-    @NotBlank(message = "비밀번호 확인은 필수입니다")
+//    @NotBlank(message = "비밀번호 확인은 필수입니다")
     String confirmPassword,
 
     @NotBlank(message = "닉네임은 필수입니다")

--- a/src/main/java/com/zb/fresh_api/api/service/MemberService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.zb.fresh_api.api.service;
 
+import com.zb.fresh_api.api.dto.SignUpRequest;
 import com.zb.fresh_api.api.dto.TermsAgreementDto;
 import com.zb.fresh_api.api.dto.request.*;
 import com.zb.fresh_api.api.dto.response.*;
@@ -8,6 +9,7 @@ import com.zb.fresh_api.api.principal.CustomUserDetailsService;
 import com.zb.fresh_api.api.provider.TokenProvider;
 import com.zb.fresh_api.api.utils.RandomUtil;
 import com.zb.fresh_api.api.utils.S3Uploader;
+import com.zb.fresh_api.common.constants.AppConstants;
 import com.zb.fresh_api.common.exception.CustomException;
 import com.zb.fresh_api.common.exception.ResponseCode;
 import com.zb.fresh_api.domain.dto.file.UploadedFile;
@@ -117,11 +119,7 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public void nickNameValidate(String nickname) {
-        boolean existsByNicknameIgnoreCase = memberReader.existActiveNickname(
-            nickname);
-        if (existsByNicknameIgnoreCase) {
-            throw new CustomException(ResponseCode.NICKNAME_ALREADY_IN_USE);
-        }
+        validateDuplicatedNickname(nickname);
     }
 
     @Transactional(readOnly = true)
@@ -129,10 +127,7 @@ public class MemberService {
         if (email == null || email.isEmpty()) {
             throw new CustomException(ResponseCode.PARAM_EMAIL_NOT_VALID);
         }
-        boolean existsByEmailAndProvider = memberReader.existsByEmailAndProvider(email, provider);
-        if (existsByEmailAndProvider) {
-            throw new CustomException(ResponseCode.EMAIL_ALREADY_IN_USE);
-        }
+        validateDuplicatedEmail(email, provider);
     }
 
     @Transactional(readOnly = true)
@@ -152,22 +147,50 @@ public class MemberService {
      * 7. 이벤트로 받은 500원을 추가합니다
      */
     @Transactional
-    public void signUp(String email, String password, String nickName,
-        List<TermsAgreementDto> termsAgreementDtos, Provider provider, String providerId) {
-        nickNameValidate(nickName);
-        emailValidate(email, provider);
+    public void signUp(SignUpRequest request) {
+        final String email = request.email();
+        final String password = request.password();
+        final String nickname = request.nickname();
+        final Provider provider = request.provider();
+        final List<TermsAgreementDto> termsAgreementDtos = request.termsAgreements();
+
+        validateDuplication(email, nickname, provider);
         validateMandatoryTermsIncluded(termsAgreementDtos);
-        Member member = memberWriter.store(
-            Member.create(nickName, email, passwordEncoder.encode(password), provider, providerId,
-                MemberRole.ROLE_USER, MemberStatus.ACTIVE));
+
+        if(provider == Provider.EMAIL) {
+            validatePasswordMatch(password, request.confirmPassword());
+            validatePasswordFormat(password);
+        }
+
+        final Member member = memberWriter.store(createMember(nickname, email, password, provider, request.providerId()));
         processTermsAgreements(termsAgreementDtos, member);
-        Point point = pointWriter.store(
-            Point.create(member, BigDecimal.valueOf(500), PointStatus.ACTIVE)
+
+        final Point point = pointWriter.store(Point.create(member, BigDecimal.valueOf(500), PointStatus.ACTIVE));
+        final PointHistory pointHistory = PointHistory.create(point, PointTransactionType.CHARGE, BigDecimal.valueOf(500), BigDecimal.valueOf(0), BigDecimal.valueOf(500), "회원가입 기념 500원 충전");
+        pointHistoryWriter.store(pointHistory);
+    }
+
+    private void validatePasswordMatch(String password, String confirmPassword) {
+        if (!password.equals(confirmPassword)) {
+            throw new CustomException(ResponseCode.INVALID_PASSWORD_MATCH);
+        }
+    }
+
+    private void validatePasswordFormat(String password) {
+        if (password.length() < AppConstants.PASSWORD_MIN_LENGTH || password.length() > AppConstants.PASSWORD_MAX_LENGTH) {
+            throw new CustomException(ResponseCode.INVALID_PASSWORD_FORMAT);
+        }
+
+        if (!password.matches(AppConstants.PASSWORD_PATTERN)) {
+            throw new CustomException(ResponseCode.INVALID_PASSWORD_FORMAT);
+        }
+    }
+
+    private Member createMember(String nickname, String email, String password, Provider provider, String providerId) {
+        return (provider == Provider.EMAIL)
+                ? Member.createForEmail(nickname, email, passwordEncoder.encode(password), provider, providerId, MemberRole.ROLE_USER, MemberStatus.ACTIVE)
+                : Member.createForOauth(nickname, email, password, provider, providerId, MemberRole.ROLE_USER, MemberStatus.ACTIVE
         );
-        pointHistoryWriter.store(
-            PointHistory.create(point, PointTransactionType.CHARGE, BigDecimal.valueOf(500),
-                BigDecimal.valueOf(0), BigDecimal.valueOf(500),
-                "회원가입 기념 500원 충전"));
     }
 
     @Transactional
@@ -327,5 +350,23 @@ public class MemberService {
             memberId);
 
         return GetAllAddressResponse.fromEntities(deliveryAddressList);
+    }
+
+    private void validateDuplication(final String email, final String nickname, final Provider provider) {
+        validateDuplicatedEmail(email, provider);
+        validateDuplicatedNickname(nickname);
+    }
+
+    private void validateDuplicatedEmail(final String email, final Provider provider) {
+        boolean existsByEmailAndProvider = memberReader.existsByEmailAndProvider(email, provider);
+        if (existsByEmailAndProvider) {
+            throw new CustomException(ResponseCode.EMAIL_ALREADY_IN_USE);
+        }
+    }
+
+    private void validateDuplicatedNickname(final String nickname) {
+        if (memberReader.existActiveNickname(nickname)) {
+            throw new CustomException(ResponseCode.NICKNAME_ALREADY_IN_USE);
+        }
     }
 }

--- a/src/main/java/com/zb/fresh_api/common/constants/AppConstants.java
+++ b/src/main/java/com/zb/fresh_api/common/constants/AppConstants.java
@@ -9,4 +9,8 @@ public class AppConstants {
     public static final String DATE_FORMAT_YYYYMMDD = "yyyy/MM/dd";
 
     public static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    public static final int PASSWORD_MIN_LENGTH = 8;
+    public static final int PASSWORD_MAX_LENGTH = 16;
+    public static final String PASSWORD_PATTERN = "^(?=.*[a-zA-Z])(?=.*\\d)(?!.*\\s).+$";
 }

--- a/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
+++ b/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
@@ -37,6 +37,9 @@ public enum ResponseCode {
     PARAM_EMAIL_NOT_VALID("1002", "입력한 이메일이 잘못되었습니다"),
     PARAM_NICKNAME_NOT_VALID("1003", "입력한 닉네임이 잘못되었습니다"),
     NOT_FOUND_MEMBER("1004", "회원 정보를 찾을 수 없습니다."),
+    INVALID_PASSWORD_MATCH("1005", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+    INVALID_PASSWORD_FORMAT("1006", "비밀번호는 최소 8글자 이상, 최대 16글자 이하로 작성해야 하며, 비밀번호는 영어와 숫자를 혼용해야 하며, 공백은 사용할 수 없습니다."),
+    INVALID_PROVIDER("1007", "회원가입 경로를 확인해주세요.(이메일, 소셜)"),
 
     /**
      * Terms (1100 ~ 1200)

--- a/src/main/java/com/zb/fresh_api/domain/entity/member/Member.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/member/Member.java
@@ -1,24 +1,16 @@
 package com.zb.fresh_api.domain.entity.member;
 
+import com.zb.fresh_api.common.exception.CustomException;
+import com.zb.fresh_api.common.exception.ResponseCode;
 import com.zb.fresh_api.domain.entity.base.BaseTimeEntity;
 import com.zb.fresh_api.domain.enums.member.MemberRole;
 import com.zb.fresh_api.domain.enums.member.MemberStatus;
 import com.zb.fresh_api.domain.enums.member.Provider;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.*;
+
 import java.time.LocalDateTime;
 import java.util.Objects;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
@@ -75,17 +67,48 @@ public class Member extends BaseTimeEntity {
     @Column(name = "seller_verified_at", columnDefinition = "datetime comment '판매자 인증 일시'")
     private LocalDateTime sellerVerifiedAt;
   
-    public static Member create(String nickname, String email, String password,
-        Provider provider, String providerId, MemberRole memberRole, MemberStatus memberStatus){
+    public static Member createForEmail(String nickname,
+                                        String email,
+                                        String password,
+                                        Provider provider,
+                                        String providerId,
+                                        MemberRole memberRole,
+                                        MemberStatus memberStatus){
+        if (provider != Provider.EMAIL || !Objects.isNull(providerId)) {
+            throw new CustomException(ResponseCode.INVALID_PROVIDER);
+        }
+
         return Member.builder()
             .nickname(nickname)
             .email(email)
             .password(password)
-            .provider(provider)
-            .providerId(providerId)
+            .provider(Provider.EMAIL)
+            .providerId(null)
             .role(memberRole)
             .status(memberStatus)
             .build();
+    }
+
+    public static Member createForOauth(String nickname,
+                                        String email,
+                                        String password,
+                                        Provider provider,
+                                        String providerId,
+                                        MemberRole memberRole,
+                                        MemberStatus memberStatus){
+        if (provider == Provider.EMAIL || Objects.isNull(providerId) || !Objects.isNull(password)) {
+            throw new CustomException(ResponseCode.INVALID_PROVIDER);
+        }
+
+        return Member.builder()
+                .nickname(nickname)
+                .email(email)
+                .password(null)
+                .provider(provider)
+                .providerId(providerId)
+                .role(memberRole)
+                .status(memberStatus)
+                .build();
     }
 
     public void updateProfile(final String nickname,

--- a/src/test/java/com/zb/fresh_api/api/controller/MemberControllerTest.java
+++ b/src/test/java/com/zb/fresh_api/api/controller/MemberControllerTest.java
@@ -1,15 +1,5 @@
 package com.zb.fresh_api.api.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zb.fresh_api.api.dto.SignUpRequest;
 import com.zb.fresh_api.api.dto.TermsAgreementDto;
@@ -18,7 +8,6 @@ import com.zb.fresh_api.api.service.MemberService;
 import com.zb.fresh_api.common.exception.CustomException;
 import com.zb.fresh_api.common.exception.ResponseCode;
 import com.zb.fresh_api.domain.enums.member.Provider;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +17,16 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = MemberController.class,
     excludeAutoConfiguration = SecurityAutoConfiguration.class
@@ -117,8 +116,7 @@ class MemberControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.code").value(ResponseCode.SUCCESS.getCode()));
 
-        verify(memberService, times(1)).signUp(request.email(), request.password(),
-            request.nickname(), request.termsAgreements(), request.provider(),request.providerId());
+        verify(memberService, times(1)).signUp(request);
     }
 
 }


### PR DESCRIPTION
## 작업
회원 가입 예외 처리 추가
- 이메일 회원의 경우 패스워드 예외를 추가했습니다.
- 소셜 로그인의 경우 Provider와 ProviderId 검증을 추가했습니다.
- 기존의 작성되어있던 테스트 코드를 주석처리했습니다. (추가 작성 필요)

## 참고 사항

## 관련 이슈
- Close #69
