### PR TITLE
FIX : 프로필 변경 API 스웨거에서 사진 등록 불가한 문제 수정

### DIFF
--- a/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/MemberController.java
@@ -107,7 +107,7 @@ public class MemberController {
             summary = "프로필 변경",
             description = "회원의 이미지 또는 닉네임을 변경한다."
     )
-    @PatchMapping(value = "/profile", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PatchMapping(value = "/profile", consumes =  MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Void>> updateProfile(
             @Parameter(hidden = true) @LoginMember Member loginMember,
             @Parameter @RequestPart(value = "request", required = false) @Valid UpdateProfileRequest request,


### PR DESCRIPTION
## 작업

1.  프로필 변경 API의 consumes를 MULTIPART_FORM_DATA_VALUE로 제한하였습니다

## 참고 사항

## 관련 이슈
- Close #86 
