### PR TITLE
FIX : 채팅방Id 생성자로직 수정

### DIFF
--- a/src/main/java/com/zb/fresh_api/api/controller/ChatController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/ChatController.java
@@ -2,6 +2,7 @@ package com.zb.fresh_api.api.controller;
 
 import com.zb.fresh_api.api.dto.request.ChatRoomRequest;
 import com.zb.fresh_api.api.dto.response.ChatRoomResponse;
+import com.zb.fresh_api.api.principal.CustomUserDetails;
 import com.zb.fresh_api.common.response.ApiResponse;
 import com.zb.fresh_api.api.service.ChatMessageService;
 import com.zb.fresh_api.api.service.ChatRoomService;
@@ -71,10 +72,11 @@ public class ChatController {
     @Operation(summary = "채팅방 나가기", description = "사용자가 채팅방을 나가면 채팅방 멤버에서 제거되고, 마지막 멤버가 나가면 채팅방 삭제")
     @PostMapping("/{chatRoomId}/leave")
     public ResponseEntity<ApiResponse<Void>> leaveChatRoom(
-            @Parameter(description = "채팅방 ID") @PathVariable String chatRoomId
+            @Parameter(description = "채팅방 ID") @PathVariable Long chatRoomId
     ) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long memberId = Long.parseLong(authentication.getName());
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        Long memberId = userDetails.member().getId();
 
         chatRoomService.leaveChatRoom(chatRoomId, memberId);
         return ApiResponse.success(ResponseCode.SUCCESS, null);

--- a/src/main/java/com/zb/fresh_api/api/controller/ChatController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/ChatController.java
@@ -5,8 +5,9 @@ import com.zb.fresh_api.api.dto.response.ChatRoomResponse;
 import com.zb.fresh_api.common.response.ApiResponse;
 import com.zb.fresh_api.api.service.ChatMessageService;
 import com.zb.fresh_api.api.service.ChatRoomService;
-import com.zb.fresh_api.domain.dto.chat.ChatMessageDto;
 import com.zb.fresh_api.common.exception.ResponseCode;
+import com.zb.fresh_api.domain.dto.chat.ChatMessageDto;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -16,6 +17,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.nio.charset.StandardCharsets;
@@ -68,8 +71,10 @@ public class ChatController {
     @Operation(summary = "채팅방 나가기", description = "사용자가 채팅방을 나가면 채팅방 멤버에서 제거되고, 마지막 멤버가 나가면 채팅방 삭제")
     @PostMapping("/{chatRoomId}/leave")
     public ResponseEntity<ApiResponse<Void>> leaveChatRoom(
-            @Parameter(description = "채팅방 ID") @PathVariable String chatRoomId,
-            @Parameter(description = "사용자 ID") @RequestParam Long memberId) {
+            @Parameter(description = "채팅방 ID") @PathVariable String chatRoomId
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long memberId = Long.parseLong(authentication.getName());
 
         chatRoomService.leaveChatRoom(chatRoomId, memberId);
         return ApiResponse.success(ResponseCode.SUCCESS, null);

--- a/src/main/java/com/zb/fresh_api/api/dto/request/ChatRoomRequest.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/request/ChatRoomRequest.java
@@ -1,6 +1,8 @@
 package com.zb.fresh_api.api.dto.request;
 
 public record ChatRoomRequest(
+        String buyerName,
+        String sellerName,
         Long buyerId,
         Long sellerId,
         Long productId,

--- a/src/main/java/com/zb/fresh_api/api/dto/response/ChatRoomResponse.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/response/ChatRoomResponse.java
@@ -1,7 +1,7 @@
 package com.zb.fresh_api.api.dto.response;
 
 public record ChatRoomResponse(
-        String chatRoomId,
+        Long chatRoomId,
         String status
 ) {
 }

--- a/src/main/java/com/zb/fresh_api/api/service/ChatRoomService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/ChatRoomService.java
@@ -3,7 +3,10 @@ package com.zb.fresh_api.api.service;
 import com.zb.fresh_api.api.dto.request.ChatRoomRequest;
 import com.zb.fresh_api.api.dto.response.ChatRoomResponse;
 import com.zb.fresh_api.domain.entity.chat.ChatRoom;
+import com.zb.fresh_api.domain.entity.chat.ChatRoomIdGenerator;
 import com.zb.fresh_api.domain.entity.chat.ChatRoomMember;
+import com.zb.fresh_api.domain.entity.member.Member;
+import com.zb.fresh_api.domain.repository.jpa.MemberJpaRepository;
 import com.zb.fresh_api.domain.repository.reader.ChatRoomReader;
 import com.zb.fresh_api.domain.repository.writer.ChatRoomMemberWriter;
 import com.zb.fresh_api.domain.repository.writer.ChatRoomWriter;
@@ -20,38 +23,51 @@ public class ChatRoomService {
     private final ChatRoomReader chatRoomReader;
     private final ChatRoomWriter chatRoomWriter;
     private final ChatRoomMemberWriter chatRoomMemberWriter;
+    private final MemberJpaRepository memberJpaRepository;
 
     @Transactional
     public ChatRoomResponse createOneToOneChatRoom(ChatRoomRequest chatRoomRequest) {
-        // 1:1 채팅방 ID 생성 (닉네임 기반)
-        String chatRoomId = ChatRoom.createOneToOne(chatRoomRequest.sellerName(), chatRoomRequest.buyerName()).getChatRoomId();
+        Member seller = memberJpaRepository.findByNickname(chatRoomRequest.sellerName())
+                .orElseThrow(() -> new CustomException(ResponseCode.NOT_FOUND_MEMBER));
+        Member buyer = memberJpaRepository.findByNickname(chatRoomRequest.buyerName())
+                .orElseThrow(() -> new CustomException(ResponseCode.NOT_FOUND_MEMBER));
+
+        // 1:1 채팅방 ID 생성
+        long chatRoomId = ChatRoomIdGenerator.generateSha256ChatRoomId(seller.getNickname(), buyer.getNickname());
 
         if (chatRoomReader.findById(chatRoomId).isPresent()) {
             throw new CustomException(ResponseCode.CHATROOM_ALREADY_EXISTS);
         }
 
-        ChatRoom chatRoom = ChatRoom.createOneToOne(chatRoomRequest.sellerName(), chatRoomRequest.buyerName());
+        // 생성된 ID로 1:1 채팅방 생성
+        ChatRoom chatRoom = ChatRoom.createOneToOne(seller.getNickname(), buyer.getNickname());
         chatRoomWriter.save(chatRoom);
 
-        chatRoomMemberWriter.save(new ChatRoomMember(chatRoom, chatRoomRequest.sellerId(), true, true));
-        chatRoomMemberWriter.save(new ChatRoomMember(chatRoom, chatRoomRequest.buyerId(), false, true));
+        chatRoomMemberWriter.save(new ChatRoomMember(chatRoom, seller.getId(), true, true));
+        chatRoomMemberWriter.save(new ChatRoomMember(chatRoom, buyer.getId(), false, true));
 
         return new ChatRoomResponse(chatRoom.getChatRoomId(), "OPENED");
     }
 
     @Transactional
     public ChatRoomResponse createOneToManyChatRoom(ChatRoomRequest chatRoomRequest) {
-        ChatRoom chatRoom = ChatRoom.createOneToMany(chatRoomRequest.sellerName(), chatRoomRequest.productId(), chatRoomRequest.categoryId());
+        // 닉네임을 통해 판매자 정보 조회
+        Member seller = memberJpaRepository.findByNickname(chatRoomRequest.sellerName())
+                .orElseThrow(() -> new CustomException(ResponseCode.NOT_FOUND_MEMBER));
+
+        // 1:10 그룹 채팅방 ID 생성
+        long chatRoomId = ChatRoomIdGenerator.generateSha256ChatRoomId(seller.getNickname(), "GROUP_CHAT");
+
+        ChatRoom chatRoom = ChatRoom.createOneToMany(seller.getNickname(), chatRoomRequest.productId(), chatRoomRequest.categoryId());
         chatRoomWriter.save(chatRoom);
 
-        chatRoomMemberWriter.save(new ChatRoomMember(chatRoom, chatRoomRequest.sellerId(), true, true));
-        chatRoomMemberWriter.save(new ChatRoomMember(chatRoom, chatRoomRequest.buyerId(), false, true));
+        chatRoomMemberWriter.save(new ChatRoomMember(chatRoom, seller.getId(), true, true));
 
         return new ChatRoomResponse(chatRoom.getChatRoomId(), "OPENED");
     }
 
     @Transactional
-    public void leaveChatRoom(String chatRoomId, Long memberId) {
+    public void leaveChatRoom(Long chatRoomId, Long memberId) {
         ChatRoom chatRoom = chatRoomReader.findById(chatRoomId)
                 .orElseThrow(() -> new CustomException(ResponseCode.NOT_FOUND_CHATROOM));
 

--- a/src/main/java/com/zb/fresh_api/api/service/ChatRoomService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/ChatRoomService.java
@@ -3,7 +3,9 @@ package com.zb.fresh_api.api.service;
 import com.zb.fresh_api.api.dto.request.ChatRoomRequest;
 import com.zb.fresh_api.api.dto.response.ChatRoomResponse;
 import com.zb.fresh_api.domain.entity.chat.ChatRoom;
+import com.zb.fresh_api.domain.entity.chat.ChatRoomMember;
 import com.zb.fresh_api.domain.repository.reader.ChatRoomReader;
+import com.zb.fresh_api.domain.repository.writer.ChatRoomMemberWriter;
 import com.zb.fresh_api.domain.repository.writer.ChatRoomWriter;
 import com.zb.fresh_api.common.exception.CustomException;
 import com.zb.fresh_api.common.exception.ResponseCode;
@@ -17,6 +19,7 @@ public class ChatRoomService {
 
     private final ChatRoomReader chatRoomReader;
     private final ChatRoomWriter chatRoomWriter;
+    private final ChatRoomMemberWriter chatRoomMemberWriter;
 
     @Transactional
     public ChatRoomResponse createOneToOneChatRoom(ChatRoomRequest chatRoomRequest) {
@@ -30,6 +33,9 @@ public class ChatRoomService {
         ChatRoom chatRoom = ChatRoom.createOneToOne(chatRoomRequest.sellerName(), chatRoomRequest.buyerName());
         chatRoomWriter.save(chatRoom);
 
+        chatRoomMemberWriter.save(new ChatRoomMember(chatRoom, chatRoomRequest.sellerId(), true, true));
+        chatRoomMemberWriter.save(new ChatRoomMember(chatRoom, chatRoomRequest.buyerId(), false, true));
+
         return new ChatRoomResponse(chatRoom.getChatRoomId(), "OPENED");
     }
 
@@ -37,6 +43,9 @@ public class ChatRoomService {
     public ChatRoomResponse createOneToManyChatRoom(ChatRoomRequest chatRoomRequest) {
         ChatRoom chatRoom = ChatRoom.createOneToMany(chatRoomRequest.sellerName(), chatRoomRequest.productId(), chatRoomRequest.categoryId());
         chatRoomWriter.save(chatRoom);
+
+        chatRoomMemberWriter.save(new ChatRoomMember(chatRoom, chatRoomRequest.sellerId(), true, true));
+        chatRoomMemberWriter.save(new ChatRoomMember(chatRoom, chatRoomRequest.buyerId(), false, true));
 
         return new ChatRoomResponse(chatRoom.getChatRoomId(), "OPENED");
     }

--- a/src/main/java/com/zb/fresh_api/api/service/ChatRoomService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/ChatRoomService.java
@@ -20,14 +20,14 @@ public class ChatRoomService {
 
     @Transactional
     public ChatRoomResponse createOneToOneChatRoom(ChatRoomRequest chatRoomRequest) {
-        // 1:1 채팅방 ID 생성
-        String chatRoomId = ChatRoom.createOneToOne(chatRoomRequest.sellerId(), chatRoomRequest.buyerId()).getChatRoomId();
+        // 1:1 채팅방 ID 생성 (닉네임 기반)
+        String chatRoomId = ChatRoom.createOneToOne(chatRoomRequest.sellerName(), chatRoomRequest.buyerName()).getChatRoomId();
 
         if (chatRoomReader.findById(chatRoomId).isPresent()) {
             throw new CustomException(ResponseCode.CHATROOM_ALREADY_EXISTS);
         }
 
-        ChatRoom chatRoom = ChatRoom.createOneToOne(chatRoomRequest.sellerId(), chatRoomRequest.buyerId());
+        ChatRoom chatRoom = ChatRoom.createOneToOne(chatRoomRequest.sellerName(), chatRoomRequest.buyerName());
         chatRoomWriter.save(chatRoom);
 
         return new ChatRoomResponse(chatRoom.getChatRoomId(), "OPENED");
@@ -35,7 +35,7 @@ public class ChatRoomService {
 
     @Transactional
     public ChatRoomResponse createOneToManyChatRoom(ChatRoomRequest chatRoomRequest) {
-        ChatRoom chatRoom = ChatRoom.createOneToMany(chatRoomRequest.sellerId(), chatRoomRequest.productId(), chatRoomRequest.categoryId());
+        ChatRoom chatRoom = ChatRoom.createOneToMany(chatRoomRequest.sellerName(), chatRoomRequest.productId(), chatRoomRequest.categoryId());
         chatRoomWriter.save(chatRoom);
 
         return new ChatRoomResponse(chatRoom.getChatRoomId(), "OPENED");

--- a/src/main/java/com/zb/fresh_api/domain/entity/chat/ChatRoom.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/chat/ChatRoom.java
@@ -17,8 +17,8 @@ public class ChatRoom {
     @Column(name = "chat_room_id")
     private String chatRoomId;
 
-    private Long sellerId;
-    private Long buyerId;
+    private String sellerName;
+    private String buyerName;
     private Long productId;
     private Long categoryId;
     private String lastMessage;
@@ -36,24 +36,24 @@ public class ChatRoom {
     }
 
     /**
-     * 1:1 채팅방 생성 (SellerId와 BuyerId를 조합하여 ChatRoomId 생성)
+     * 1:1 채팅방 생성 (SellerName과 BuyerName을 조합하여 ChatRoomId 생성)
      */
-    public static ChatRoom createOneToOne(Long sellerId, Long buyerId) {
+    public static ChatRoom createOneToOne(String sellerName, String buyerName) {
         ChatRoom chatRoom = new ChatRoom();
-        chatRoom.chatRoomId = generateChatRoomId(sellerId, buyerId);
-        chatRoom.sellerId = sellerId;
-        chatRoom.buyerId = buyerId;
+        chatRoom.chatRoomId = generateChatRoomId(sellerName, buyerName); // 닉네임 조합으로 ID 생성
+        chatRoom.sellerName = sellerName;
+        chatRoom.buyerName = buyerName;
         chatRoom.maxParticipants = 2;  // 1:1 채팅방이므로 최대 인원을 2로 설정
         return chatRoom;
     }
 
     /**
-     * 1:10 그룹 채팅방 생성 (SellerId와 현재 시간을 조합하여 ChatRoomId 생성)
+     * 1:10 그룹 채팅방 생성 (SellerName과 현재 시간을 조합하여 ChatRoomId 생성)
      */
-    public static ChatRoom createOneToMany(Long sellerId, Long productId, Long categoryId) {
+    public static ChatRoom createOneToMany(String sellerName, Long productId, Long categoryId) {
         ChatRoom chatRoom = new ChatRoom();
-        chatRoom.chatRoomId = generateChatRoomIdForGroup(sellerId);
-        chatRoom.sellerId = sellerId;
+        chatRoom.chatRoomId = generateChatRoomIdForGroup(sellerName); // 판매자 닉네임 기반 ID 생성
+        chatRoom.sellerName = sellerName;
         chatRoom.productId = productId;
         chatRoom.categoryId = categoryId;
         chatRoom.maxParticipants = 10;  // 1:10 채팅방이므로 최대 인원을 10으로 설정
@@ -61,17 +61,17 @@ public class ChatRoom {
     }
 
     /**
-     * 1:1 채팅방 ID 생성 메서드 (SellerId + BuyerId)
+     * 1:1 채팅방 ID 생성 메서드 (SellerName + BuyerName)
      */
-    private static String generateChatRoomId(Long sellerId, Long buyerId) {
-        return sellerId + "_" + buyerId;
+    private static String generateChatRoomId(String sellerName, String buyerName) {
+        return sellerName + "_" + buyerName;
     }
 
     /**
-     * 1:10 그룹 채팅방 ID 생성 메서드 (SellerId + 현재 시스템 시간)
+     * 1:10 그룹 채팅방 ID 생성 메서드 (SellerName + 현재 시스템 시간)
      */
-    private static String generateChatRoomIdForGroup(Long sellerId) {
-        return sellerId + "_" + System.currentTimeMillis();
+    private static String generateChatRoomIdForGroup(String sellerName) {
+        return sellerName + "_" + System.currentTimeMillis();
     }
 
     /**

--- a/src/main/java/com/zb/fresh_api/domain/entity/chat/ChatRoomIdGenerator.java
+++ b/src/main/java/com/zb/fresh_api/domain/entity/chat/ChatRoomIdGenerator.java
@@ -1,0 +1,29 @@
+package com.zb.fresh_api.domain.entity.chat;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+public class ChatRoomIdGenerator {
+
+    public static long generateSha256ChatRoomId(String sellerName, String buyerName) {
+        try {
+            String[] nicknames = {sellerName, buyerName};
+            Arrays.sort(nicknames);
+            String combinedName = nicknames[0] + nicknames[1];
+
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashBytes = digest.digest(combinedName.getBytes(StandardCharsets.UTF_8));
+
+            long chatRoomId = 0;
+            for (int i = 0; i < Math.min(8, hashBytes.length); i++) {
+                chatRoomId = (chatRoomId << 8) | (hashBytes[i] & 0xFF);
+            }
+            return Math.abs(chatRoomId);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("Error generating SHA-256 ID", e);
+        }
+    }
+}
+

--- a/src/main/java/com/zb/fresh_api/domain/repository/jpa/ChatRoomRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/jpa/ChatRoomRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.repository.CrudRepository;
 
 import java.util.Optional;
 
-public interface ChatRoomRepository extends CrudRepository<ChatRoom, String> {
+public interface ChatRoomRepository extends CrudRepository<ChatRoom, Long> {
     Optional<ChatRoom> findBySellerIdAndBuyerIdAndProductId(Long sellerId, Long buyerId, Long productId);
 }

--- a/src/main/java/com/zb/fresh_api/domain/repository/jpa/MemberJpaRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/jpa/MemberJpaRepository.java
@@ -20,4 +20,6 @@ public interface MemberJpaRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmailAndProvider(String email, Provider provider);
 
     Optional<Member> findByIdAndDeletedAtIsNull(Long id);
+
+    Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/com/zb/fresh_api/domain/repository/reader/ChatRoomReader.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/reader/ChatRoomReader.java
@@ -13,7 +13,7 @@ public class ChatRoomReader {
 
     private final ChatRoomRepository chatRoomRepository;
 
-    public Optional<ChatRoom> findById(String chatRoomId) {
+    public Optional<ChatRoom> findById(Long chatRoomId) {
         return chatRoomRepository.findById(chatRoomId);
     }
 

--- a/src/main/java/com/zb/fresh_api/domain/repository/writer/ChatRoomWriter.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/writer/ChatRoomWriter.java
@@ -1,6 +1,8 @@
 package com.zb.fresh_api.domain.repository.writer;
 
 import com.zb.fresh_api.domain.entity.chat.ChatRoom;
+import com.zb.fresh_api.domain.entity.chat.ChatRoomMember;
+import com.zb.fresh_api.domain.repository.jpa.ChatRoomMemberRepository;
 import com.zb.fresh_api.domain.repository.jpa.ChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -10,6 +12,7 @@ import org.springframework.stereotype.Repository;
 public class ChatRoomWriter {
 
     private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberRepository ChatRoomMemberRepository;
 
     public void save(ChatRoom chatRoom) {
         chatRoomRepository.save(chatRoom);
@@ -17,5 +20,9 @@ public class ChatRoomWriter {
 
     public void delete(ChatRoom chatRoom) {
         chatRoomRepository.delete(chatRoom);
+    }
+
+    public void save(ChatRoomMember member) {
+        ChatRoomMemberRepository.save(member);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,7 +28,11 @@ api:
       endpoint: /ws
       allowed-origins:
         - http://localhost:3000
+        - https://localhost:3000
         - http://localhost:8080
+        - https://localhost:8080
+        - http://api.jihun-dev.kr
+        - https://api.jihun-dev.kr
     broker:
       relay:
         enabled: true


### PR DESCRIPTION
## 작업
API 테스트를 위한 member Id required 해제 
채팅방ID 생성로직 수정
채팅방 생성자 로직 추가
- 채팅방아이디를 생성할때 닉네임을 조합하고 SHA-256를 활용하여 숫자로 변경하여 채팅방 id 저장하도록 수정

## 참고 사항

## 관련 이슈
- Close #85
