### PR TITLE
FEAT : 판매자 상품 목록 조회 API 추가 

### DIFF
--- a/src/main/java/com/zb/fresh_api/api/controller/ProductController.java
+++ b/src/main/java/com/zb/fresh_api/api/controller/ProductController.java
@@ -5,6 +5,7 @@ import com.zb.fresh_api.api.dto.request.AddProductRequest;
 import com.zb.fresh_api.api.dto.request.BuyProductRequest;
 import com.zb.fresh_api.api.dto.request.DeleteProductRequest;
 import com.zb.fresh_api.api.dto.request.GetAllProductByConditionsRequest;
+import com.zb.fresh_api.api.dto.request.GetSellerProducts;
 import com.zb.fresh_api.api.dto.request.UpdateProductRequest;
 import com.zb.fresh_api.api.dto.response.AddProductResponse;
 import com.zb.fresh_api.api.dto.response.BuyProductResponse;
@@ -113,19 +114,23 @@ public class ProductController {
         return ApiResponse.success(ResponseCode.SUCCESS,response);
     }
 
-    // TODO 키워드
-    //  제목
-    //  상품 설명
-    //  판매자 이름
-    @Operation(
-        summary = "상품 목록 조회",
-        description = "키워드 또는 카테고리 타입 등을 통해 상품을 상세 조회합니다."
-    )
     @GetMapping()
     public ResponseEntity<ApiResponse<GetAllProductByConditionsResponse>> getAllProductByConditions(
         GetAllProductByConditionsRequest request) {
         GetAllProductByConditionsResponse products = productService.findProducts(request);
         return ApiResponse.success(ResponseCode.SUCCESS, products);
+    }
+
+    @Operation(
+        summary = "판매자 상품 목록 조회",
+        description = "판매자가 등록한 상품 목록을 조회합니다."
+    )
+    @GetMapping("/seller")
+    public ResponseEntity<ApiResponse<GetAllProductByConditionsResponse>> getSellerProducts(
+        GetSellerProducts request,
+        @Parameter(hidden = true) @LoginMember Member loginMember) {
+        GetAllProductByConditionsResponse sellerProducts = productService.getSellerProducts(request, loginMember);
+        return ApiResponse.success(ResponseCode.SUCCESS, sellerProducts);
     }
 
     @Operation(

--- a/src/main/java/com/zb/fresh_api/api/dto/request/GetSellerProducts.java
+++ b/src/main/java/com/zb/fresh_api/api/dto/request/GetSellerProducts.java
@@ -1,0 +1,12 @@
+package com.zb.fresh_api.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "상품 목록 조회 시 사용하는 요청")
+public record GetSellerProducts(
+    @Schema(description = "페이지 번호", defaultValue = "0")
+    int page,
+
+    @Schema(description = "페이지 크기",defaultValue = "20")
+    int size
+){}

--- a/src/main/java/com/zb/fresh_api/api/service/ProductService.java
+++ b/src/main/java/com/zb/fresh_api/api/service/ProductService.java
@@ -4,6 +4,7 @@ import com.zb.fresh_api.api.dto.request.AddProductRequest;
 import com.zb.fresh_api.api.dto.request.BuyProductRequest;
 import com.zb.fresh_api.api.dto.request.DeleteProductRequest;
 import com.zb.fresh_api.api.dto.request.GetAllProductByConditionsRequest;
+import com.zb.fresh_api.api.dto.request.GetSellerProducts;
 import com.zb.fresh_api.api.dto.request.UpdateProductRequest;
 import com.zb.fresh_api.api.dto.response.AddProductResponse;
 import com.zb.fresh_api.api.dto.response.BuyProductResponse;
@@ -209,6 +210,14 @@ public class ProductService {
         return GetAllProductByConditionsResponse.fromEntities(products);
     }
 
+    public GetAllProductByConditionsResponse getSellerProducts(GetSellerProducts request, Member member) {
+        if(!member.isSeller()){
+            throw new CustomException(ResponseCode.MEMBER_NOT_SELLER);
+        }
+
+        return GetAllProductByConditionsResponse.fromEntities( productReader.findByMemberId(request, member.getId()));
+    }
+
     public FindAllProductLikeResponse findAllProductLike(Long memberId){
         List<Long> productLikes = productLikeReader.findProductIdByMemberId(memberId);
 
@@ -249,5 +258,6 @@ public class ProductService {
 
         productLikeWriter.delete(productLike);
     }
+
 
 }

--- a/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
+++ b/src/main/java/com/zb/fresh_api/common/exception/ResponseCode.java
@@ -40,6 +40,7 @@ public enum ResponseCode {
     INVALID_PASSWORD_MATCH("1005", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
     INVALID_PASSWORD_FORMAT("1006", "비밀번호는 최소 8글자 이상, 최대 16글자 이하로 작성해야 하며, 비밀번호는 영어와 숫자를 혼용해야 하며, 공백은 사용할 수 없습니다."),
     INVALID_PROVIDER("1007", "회원가입 경로를 확인해주세요.(이메일, 소셜)"),
+    MEMBER_NOT_SELLER("1008", "사용자가 판매자가 아닙니다"),
 
     /**
      * Terms (1100 ~ 1200)

--- a/src/main/java/com/zb/fresh_api/domain/repository/query/ProductQueryRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/query/ProductQueryRepository.java
@@ -9,6 +9,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.zb.fresh_api.api.dto.request.GetAllProductByConditionsRequest;
+import com.zb.fresh_api.api.dto.request.GetSellerProducts;
 import com.zb.fresh_api.domain.dto.recommend.CategoryProductOrder;
 import com.zb.fresh_api.domain.dto.recommend.RecommendProductSummary;
 import com.zb.fresh_api.domain.dto.recommend.SellerProductOrder;
@@ -69,6 +70,20 @@ public class ProductQueryRepository {
         long total = query.fetchCount();
 
         return new PageImpl<>(products, pageable, total);
+    }
+
+    public Page<Product> findByMemberId(GetSellerProducts request, Long memberId){
+        Pageable pageable = PageRequest.of(request.page(), request.size());
+        JPAQuery<Product> query = jpaQueryFactory.selectFrom(product)
+            .where(product.member.id.eq(memberId))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize());
+
+        List<Product> products = query.fetch();
+        long total = query.fetchCount();
+
+        return new PageImpl<>(products, pageable, total);
+
     }
 
     public List<RecommendProductSummary> findAllRandomProduct(int size) {

--- a/src/main/java/com/zb/fresh_api/domain/repository/reader/ProductReader.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/reader/ProductReader.java
@@ -1,6 +1,7 @@
 package com.zb.fresh_api.domain.repository.reader;
 
 import com.zb.fresh_api.api.dto.request.GetAllProductByConditionsRequest;
+import com.zb.fresh_api.api.dto.request.GetSellerProducts;
 import com.zb.fresh_api.common.exception.CustomException;
 import com.zb.fresh_api.common.exception.ResponseCode;
 import com.zb.fresh_api.domain.annotation.Reader;
@@ -23,6 +24,10 @@ public class ProductReader {
 
     public Optional<Product> findById(Long id){
         return productJpaRepository.findById(id);
+    }
+
+    public Page<Product> findByMemberId(GetSellerProducts request, Long memberId) {
+        return productQueryRepository.findByMemberId(request, memberId);
     }
 
     public Product getById(Long id){


### PR DESCRIPTION
## 작업

1. 판매자가 본인이 등록한 상품의 목록을 조회하는 API를 추가하였습니다
  *  판매자의 id를 통해 상품을 검색합니다
## 참고 사항

## 관련 이슈
- Close #95 
