### PR TITLE
FIX : 상품 조회시 삭제된 상품 조회안되도록 수정

### DIFF
--- a/src/main/java/com/zb/fresh_api/domain/repository/query/ProductQueryRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/query/ProductQueryRepository.java
@@ -75,7 +75,8 @@ public class ProductQueryRepository {
     public Page<Product> findByMemberId(GetSellerProducts request, Long memberId){
         Pageable pageable = PageRequest.of(request.page(), request.size());
         JPAQuery<Product> query = jpaQueryFactory.selectFrom(product)
-            .where(product.member.id.eq(memberId))
+            .where(product.member.id.eq(memberId)
+                .and(isNotDeleted(product)))
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize());
 


### PR DESCRIPTION
## 작업

1. 상품 조회하는 메서드가 조회되는 에러를 수정하였습니다
  *  상품 조회 쿼리에 삭제된 날짜의 null여부를 판독하도록 추가하였습니다

## 참고 사항

## 관련 이슈
- Close #100 
