### PR TITLE
Fix : 탈퇴된 이메일 사용불가 문제 

### DIFF
--- a/src/main/java/com/zb/fresh_api/domain/repository/jpa/MemberJpaRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/jpa/MemberJpaRepository.java
@@ -16,7 +16,7 @@ public interface MemberJpaRepository extends JpaRepository<Member, Long> {
     boolean existsByEmailAndProviderAndDeletedAtIsNull(String email, Provider provider);
     boolean existsByNickname(String nickname);
 
-    Optional<Member> findByEmailAndProvider(String email, Provider provider);
+    Optional<Member> findByEmailAndProviderAndDeletedAtIsNull(String email, Provider provider);
 
     Optional<Member> findByIdAndDeletedAtIsNull(Long id);
 

--- a/src/main/java/com/zb/fresh_api/domain/repository/jpa/MemberJpaRepository.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/jpa/MemberJpaRepository.java
@@ -13,8 +13,7 @@ public interface MemberJpaRepository extends JpaRepository<Member, Long> {
 
     boolean existsByNicknameIgnoreCase(String nickname);
 
-    boolean existsByEmailAndProvider(String email, Provider provider);
-
+    boolean existsByEmailAndProviderAndDeletedAtIsNull(String email, Provider provider);
     boolean existsByNickname(String nickname);
 
     Optional<Member> findByEmailAndProvider(String email, Provider provider);

--- a/src/main/java/com/zb/fresh_api/domain/repository/reader/MemberReader.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/reader/MemberReader.java
@@ -25,7 +25,7 @@ public class MemberReader {
     }
 
     public Member getByEmailAndProvider(String email, Provider provider) {
-        return memberJpaRepository.findByEmailAndProvider(email, provider)
+        return memberJpaRepository.findByEmailAndProviderAndDeletedAtIsNull(email, provider)
                 .orElseThrow(() -> new CustomException(ResponseCode.NOT_FOUND_MEMBER));
     }
 

--- a/src/main/java/com/zb/fresh_api/domain/repository/reader/MemberReader.java
+++ b/src/main/java/com/zb/fresh_api/domain/repository/reader/MemberReader.java
@@ -30,7 +30,7 @@ public class MemberReader {
     }
 
     public boolean existsByEmailAndProvider(String email, Provider provider) {
-        return memberJpaRepository.existsByEmailAndProvider(email, provider);
+        return memberJpaRepository.existsByEmailAndProviderAndDeletedAtIsNull(email, provider);
     }
 
     public MemberWithPoint getMemberWithPointByEmailAndProvider(String email, Provider provider) {


### PR DESCRIPTION
## 작업

1. 토큰을 통해 회원 정보 조회 시  DeletedAtIsNull 조건 추가
2. 회원가입 시 이메일 중복 검사에서 DeletedAtIsNull 조건 추가

## 참고 사항

## 관련 이슈
- Close #107
